### PR TITLE
Add select-all option to user permission checklists

### DIFF
--- a/public/scripts/erp.js
+++ b/public/scripts/erp.js
@@ -4343,9 +4343,32 @@ $(".save-branch").on("click", async e => {
 
 let editingUserId = null
 
+const permissionModules = ['register', 'trip', 'sales', 'account_cut'];
+
+function updateSelectAllCheckbox(module) {
+    const container = $(`.permission-list[data-module="${module}"]`);
+    const selectAll = $(`.permission-select-all[data-module="${module}"]`);
+    const checkboxes = container.find('.permission-checkbox');
+
+    if (!selectAll.length) {
+        return;
+    }
+
+    if (!checkboxes.length) {
+        selectAll.prop('checked', false);
+        selectAll.prop('indeterminate', false);
+        return;
+    }
+
+    const total = checkboxes.length;
+    const checkedCount = checkboxes.filter(':checked').length;
+
+    selectAll.prop('checked', checkedCount === total);
+    selectAll.prop('indeterminate', checkedCount > 0 && checkedCount < total);
+}
+
 function renderPermissions(perms) {
-    const modules = ['register', 'trip', 'sales', 'account_cut'];
-    modules.forEach(m => {
+    permissionModules.forEach(m => {
         const container = $(`.permission-list[data-module="${m}"]`);
         container.html('');
         if (perms[m]) {
@@ -4354,8 +4377,22 @@ function renderPermissions(perms) {
                 container.append(`<div class="form-check"><input class="form-check-input permission-checkbox" type="checkbox" value="${p.id}" id="${id}" ${p.allow ? 'checked' : ''}><label class="form-check-label" for="${id}">${p.description}</label></div>`);
             });
         }
+        updateSelectAllCheckbox(m);
     });
 }
+
+$(document).on('change', '.permission-select-all', function () {
+    const module = $(this).data('module');
+    const checked = $(this).is(':checked');
+    $(this).prop('indeterminate', false);
+    $(`.permission-list[data-module="${module}"] .permission-checkbox`).prop('checked', checked);
+    updateSelectAllCheckbox(module);
+});
+
+$(document).on('change', '.permission-checkbox', function () {
+    const module = $(this).closest('.permission-list').data('module');
+    updateSelectAllCheckbox(module);
+});
 
 $(".user-settings-nav").on("click", async e => {
     const branchSelect = $(".user-branches")

--- a/views/erpscreen.pug
+++ b/views/erpscreen.pug
@@ -1272,12 +1272,24 @@ block content
                         a.nav-link(data-bs-toggle="tab" href="#hesap") Hesap Kesim
                 .tab-content.mt-3.px-2(style="overflow-y: auto;height: 40vh;")
                     .tab-pane.fade.show.active#kasa
+                        .form-check.mb-2
+                            input#select-all-register.form-check-input.permission-select-all(type="checkbox" data-module="register")
+                            label.form-check-label(for="select-all-register") Tümünü Seç
                         .permission-list(data-module="register")
                     .tab-pane.fade#sefer
+                        .form-check.mb-2
+                            input#select-all-trip.form-check-input.permission-select-all(type="checkbox" data-module="trip")
+                            label.form-check-label(for="select-all-trip") Tümünü Seç
                         .permission-list(data-module="trip")
                     .tab-pane.fade#satis
+                        .form-check.mb-2
+                            input#select-all-sales.form-check-input.permission-select-all(type="checkbox" data-module="sales")
+                            label.form-check-label(for="select-all-sales") Tümünü Seç
                         .permission-list(data-module="sales")
                     .tab-pane.fade#hesap
+                        .form-check.mb-2
+                            input#select-all-account.form-check-input.permission-select-all(type="checkbox" data-module="account_cut")
+                            label.form-check-label(for="select-all-account") Tümünü Seç
                         .permission-list(data-module="account_cut")
 
     .members


### PR DESCRIPTION
## Summary
- add "Tümünü Seç" checkboxes to each permission tab so all permissions can be toggled at once
- update the ERP script to keep the new select-all checkboxes in sync with individual permission selections

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68d050419ad88322b9ef376cfcc11f9f