### PR TITLE
Fix remove route stop interaction

### DIFF
--- a/views/mixins/routeStop.pug
+++ b/views/mixins/routeStop.pug
@@ -1,4 +1,4 @@
-.route-stop.text-center(data-stop-id=routeStop.stopId)
+.route-stop.text-center(data-stop-id=routeStop.stopId data-duration=routeStop.duration)
     -if(routeStop.isFirst == false || routeStop.isFirst == "false"){
         .d-flex.flex-column.align-items-center._route-stop-duration
             i.fa-solid.fa-chevron-up.text-primary

--- a/views/mixins/routeStopsList.pug
+++ b/views/mixins/routeStopsList.pug
@@ -1,5 +1,5 @@
-each rs in routeStops 
-    .route-stop.text-center(data-stop-id=rs.stopId)
+each rs in routeStops
+    .route-stop.text-center(data-stop-id=rs.stopId data-duration=rs.duration)
         -if(rs.isFirst == false || rs.isFirst == "false"){
             .d-flex.flex-column.align-items-center._route-stop-duration
                 i.fa-solid.fa-chevron-up.text-primary


### PR DESCRIPTION
## Summary
- add a reusable helper to keep the client-side route stop list in sync with the DOM, normalizing per-stop durations and the routeStops array
- use delegated click handling so remove buttons work for existing and newly added route stops while resetting the new first stop's duration back to zero
- persist duration metadata on rendered route stops so removals preserve timings and keep the backend payload current when durations are edited

## Testing
- not run (not provided)

------
https://chatgpt.com/codex/tasks/task_e_68d05bbffb4483228e1631c805ec44e7