### PR TITLE
Align admin popups with column layout

### DIFF
--- a/controllers/erpController.js
+++ b/controllers/erpController.js
@@ -2190,6 +2190,25 @@ exports.postSaveBusPlan = async (req, res, next) => {
     }
 };
 
+exports.postDeleteBusPlan = async (req, res, next) => {
+    try {
+        const id = Number(req.body.id);
+        if (!id) {
+            return res.status(400).json({ message: "Geçersiz plan bilgisi" });
+        }
+
+        const deleted = await req.models.BusModel.destroy({ where: { id } });
+        if (!deleted) {
+            return res.status(404).json({ message: "Otobüs planı bulunamadı" });
+        }
+
+        res.json({ message: "Silindi" });
+    } catch (err) {
+        console.error("Bus plan delete error:", err);
+        res.status(500).json({ message: err.message });
+    }
+};
+
 exports.getBusesList = async (req, res, next) => {
     const buses = await req.models.Bus.findAll()
 
@@ -2334,6 +2353,25 @@ exports.postAddPrice = async (req, res, next) => {
     }
 }
 
+exports.postDeletePrice = async (req, res, next) => {
+    try {
+        const id = Number(req.body.id);
+        if (!id) {
+            return res.status(400).json({ message: "Geçersiz fiyat bilgisi" });
+        }
+
+        const deleted = await req.models.Price.destroy({ where: { id } });
+        if (!deleted) {
+            return res.status(404).json({ message: "Fiyat bulunamadı" });
+        }
+
+        res.json({ message: "Silindi" });
+    } catch (err) {
+        console.error("Price delete error:", err);
+        res.status(500).json({ message: err.message });
+    }
+};
+
 exports.getBus = async (req, res, next) => {
     const id = req.query.id
     const licensePlate = req.query.licensePlate
@@ -2370,6 +2408,25 @@ exports.postSaveBus = async (req, res, next) => {
         }
     } catch (err) {
         console.error("Hata:", err);
+        res.status(500).json({ message: err.message });
+    }
+};
+
+exports.postDeleteBus = async (req, res, next) => {
+    try {
+        const id = Number(req.body.id);
+        if (!id) {
+            return res.status(400).json({ message: "Geçersiz otobüs bilgisi" });
+        }
+
+        const deleted = await req.models.Bus.destroy({ where: { id } });
+        if (!deleted) {
+            return res.status(404).json({ message: "Otobüs bulunamadı" });
+        }
+
+        res.json({ message: "Silindi" });
+    } catch (err) {
+        console.error("Bus delete error:", err);
         res.status(500).json({ message: err.message });
     }
 };
@@ -2517,6 +2574,26 @@ exports.postSaveStaff = async (req, res, next) => {
     }
 };
 
+exports.postDeleteStaff = async (req, res, next) => {
+    try {
+        const id = Number(req.body.id);
+        if (!id) {
+            return res.status(400).json({ message: "Geçersiz personel bilgisi" });
+        }
+
+        const staff = await req.models.Staff.findByPk(id);
+        if (!staff) {
+            return res.status(404).json({ message: "Personel bulunamadı" });
+        }
+
+        await staff.destroy();
+        res.json({ message: "Silindi" });
+    } catch (err) {
+        console.error("Staff delete error:", err);
+        res.status(500).json({ message: err.message });
+    }
+};
+
 exports.getStopsList = async (req, res, next) => {
     const stops = await req.models.Stop.findAll();
     const places = await req.commonModels.Place.findAll()
@@ -2585,6 +2662,26 @@ exports.postSaveStop = async (req, res, next) => {
         }
     } catch (err) {
         console.error("Hata:", err);
+        res.status(500).json({ message: err.message });
+    }
+};
+
+exports.postDeleteStop = async (req, res, next) => {
+    try {
+        const id = Number(req.body.id);
+        if (!id) {
+            return res.status(400).json({ message: "Geçersiz durak bilgisi" });
+        }
+
+        const stop = await req.models.Stop.findByPk(id);
+        if (!stop) {
+            return res.status(404).json({ message: "Durak bulunamadı" });
+        }
+
+        await stop.destroy();
+        res.json({ message: "Silindi" });
+    } catch (err) {
+        console.error("Stop delete error:", err);
         res.status(500).json({ message: err.message });
     }
 };
@@ -2699,6 +2796,28 @@ exports.postSaveRoute = async (req, res, next) => {
         res.status(500).json({ message: err.message });
     }
 }
+
+exports.postDeleteRoute = async (req, res, next) => {
+    try {
+        const id = Number(req.body.id);
+        if (!id) {
+            return res.status(400).json({ message: "Geçersiz hat bilgisi" });
+        }
+
+        const route = await req.models.Route.findByPk(id);
+        if (!route) {
+            return res.status(404).json({ message: "Hat bulunamadı" });
+        }
+
+        await req.models.RouteStop.destroy({ where: { routeId: id } });
+        await route.destroy();
+
+        res.json({ message: "Silindi" });
+    } catch (err) {
+        console.error("Route delete error:", err);
+        res.status(500).json({ message: err.message });
+    }
+};
 
 exports.getTripsList = async (req, res, next) => {
     const date = req.query.date
@@ -2829,6 +2948,25 @@ exports.postSaveBranch = async (req, res, next) => {
         }
     } catch (err) {
         console.error("Hata:", err);
+        res.status(500).json({ message: err.message });
+    }
+};
+
+exports.postDeleteBranch = async (req, res, next) => {
+    try {
+        const id = Number(req.body.id);
+        if (!id) {
+            return res.status(400).json({ message: "Geçersiz şube bilgisi" });
+        }
+
+        const deleted = await req.models.Branch.destroy({ where: { id } });
+        if (!deleted) {
+            return res.status(404).json({ message: "Şube bulunamadı" });
+        }
+
+        res.json({ message: "Silindi" });
+    } catch (err) {
+        console.error("Branch delete error:", err);
         res.status(500).json({ message: err.message });
     }
 };
@@ -3106,6 +3244,29 @@ exports.postSaveUser = async (req, res, next) => {
 
     } catch (err) {
         console.error("Hata:", err);
+        res.status(500).json({ message: err.message });
+    }
+};
+
+exports.postDeleteUser = async (req, res, next) => {
+    try {
+        const id = Number(req.body.id);
+        if (!id) {
+            return res.status(400).json({ message: "Geçersiz kullanıcı bilgisi" });
+        }
+
+        const user = await req.models.FirmUser.findByPk(id);
+        if (!user) {
+            return res.status(404).json({ message: "Kullanıcı bulunamadı" });
+        }
+
+        await req.models.FirmUserPermission.destroy({ where: { firmUserId: id } });
+        await req.models.CashRegister.destroy({ where: { userId: id } });
+        await user.destroy();
+
+        res.json({ message: "Silindi" });
+    } catch (err) {
+        console.error("User delete error:", err);
         res.status(500).json({ message: err.message });
     }
 };

--- a/routes/erp.js
+++ b/routes/erp.js
@@ -60,12 +60,14 @@ router.get('/get-search-table', erpController.getSearchTable);
 
 router.get('/get-bus-plan-panel', erpController.getBusPlanPanel);
 router.post('/post-save-bus-plan', erpController.postSaveBusPlan);
+router.post('/post-delete-bus-plan', erpController.postDeleteBusPlan);
 
 router.get('/get-bus-models-data', erpController.getBusModelsData);
 
 router.get('/get-buses-list', erpController.getBusesList);
 router.get('/get-bus', erpController.getBus);
 router.post('/post-save-bus', erpController.postSaveBus);
+router.post('/post-delete-bus', erpController.postDeleteBus);
 router.get('/get-buses-data', erpController.getBusesData);
 router.post('/post-trip-bus', erpController.postTripBus);
 router.post('/post-trip-bus-plan', erpController.postTripBusPlan);
@@ -77,16 +79,19 @@ router.post('/post-refund-cargo', erpController.postRefundCargo);
 router.get('/get-staffs-list', erpController.getStaffsList);
 router.get('/get-staff', erpController.getStaff);
 router.post('/post-save-staff', erpController.postSaveStaff);
+router.post('/post-delete-staff', erpController.postDeleteStaff);
 
 router.get('/get-stops-list', erpController.getStopsList);
 router.get('/get-stop', erpController.getStop);
 router.post('/post-save-stop', erpController.postSaveStop);
+router.post('/post-delete-stop', erpController.postDeleteStop);
 router.get('/get-stops-data', erpController.getStopsData);
 router.get('/get-places-data', erpController.getPlacesData);
 
 router.get('/get-prices-list', erpController.getPricesList);
 router.post('/post-save-prices', erpController.postSavePrices);
 router.post('/post-add-price', erpController.postAddPrice);
+router.post('/post-delete-price', erpController.postDeletePrice);
 
 router.get('/get-routes-data', erpController.getRoutesData);
 router.get('/get-routes-list', erpController.getRoutesList);
@@ -94,6 +99,7 @@ router.get('/get-route', erpController.getRoute);
 router.get('/get-route-stop', erpController.getRouteStop);
 router.get('/get-route-stops-list', erpController.getRouteStopsList);
 router.post('/post-save-route', erpController.postSaveRoute);
+router.post('/post-delete-route', erpController.postDeleteRoute);
 
 router.get('/get-trips-list', erpController.getTripsList);
 router.post('/post-save-trip', erpController.postSaveTrip);
@@ -101,11 +107,13 @@ router.post('/post-save-trip', erpController.postSaveTrip);
 router.get('/get-branches-list', erpController.getBranchesList);
 router.get('/get-branch', erpController.getBranch);
 router.post('/post-save-branch', erpController.postSaveBranch);
+router.post('/post-delete-branch', erpController.postDeleteBranch);
 
 router.get('/get-users-list', erpController.getUsersList);
 router.get('/get-user', erpController.getUser);
 router.get('/get-users-by-branch', erpController.getUsersByBranch);
 router.post('/post-save-user', erpController.postSaveUser);
+router.post('/post-delete-user', erpController.postDeleteUser);
 
 router.get('/get-customers-list', erpController.getCustomersList);
 router.get('/get-customer', erpController.getCustomer);

--- a/views/erpscreen.pug
+++ b/views/erpscreen.pug
@@ -528,11 +528,14 @@ block content
                     button.btn.mb-2.add-bus-plan
                         i.fa-solid.fa-plus.me-2
                         | EKLE
-                .d-flex
-                    .col-6
-                        p.text-center.mb-0 Plan Adı
-                    .col-6
-                        p.text-center.mb-0 Açıklama
+                .d-flex.align-items-center.mb-2
+                    .d-flex.col-11
+                        .col-6
+                            p.text-center.mb-0 Plan Adı
+                        .col-6
+                            p.text-center.mb-0 Açıklama
+                    .col-1
+                        p.text-center.mb-0 İşlem
                 .bus-plan-list.d-flex.flex-column.gap-3.p-2
             .col-6.d-flex.gap-3.p-3.align-items-start.bus-plan-panel
 
@@ -547,13 +550,16 @@ block content
                     button.btn.mb-2.add-bus
                         i.fa-solid.fa-plus.me-2
                         | EKLE
-                .d-flex.mb-2
-                    .col-4
-                        p.text-center.m-0 Plaka
-                    .col-4
-                        p.text-center.m-0 Otobüs Modeli
-                    .col-4
-                        p.text-center.m-0 Telefon
+                .d-flex.align-items-center.mb-2
+                    .d-flex.col-11
+                        .col-4
+                            p.text-center.m-0 Plaka
+                        .col-4
+                            p.text-center.m-0 Otobüs Modeli
+                        .col-4
+                            p.text-center.m-0 Telefon
+                    .col-1
+                        p.text-center.m-0 İşlem
                 .bus-list-nodes.d-flex.flex-column.gap-3
 
             .bus-info.h-100
@@ -611,13 +617,16 @@ block content
                     button.btn.mb-2.add-staff
                         i.fa-solid.fa-plus.me-2
                         | EKLE
-                .d-flex.mb-2
-                    .col-4
-                        p.text-center.mb-0 Kimlik No
-                    .col-4
-                        p.text-center.mb-0 İsim Soyisim
-                    .col-4
-                        p.text-center.mb-0 Görev
+                .d-flex.align-items-center.mb-2
+                    .d-flex.col-11
+                        .col-4
+                            p.text-center.mb-0 Kimlik No
+                        .col-4
+                            p.text-center.mb-0 İsim Soyisim
+                        .col-4
+                            p.text-center.mb-0 Görev
+                    .col-1
+                        p.text-center.mb-0 İşlem
                 .staff-list-nodes.d-flex.flex-column.gap-3.p-2
             .col-6.flex-column.gap-3.p-3.align-items-start.staff-panel
                 .input-group
@@ -670,11 +679,14 @@ block content
                     button.btn.mb-2.add-stop
                         i.fa-solid.fa-plus.me-2
                         | EKLE
-                .d-flex
-                    .col-6
-                        p.text-center.mb-0 Durak Adı
-                    .col-6
-                        p.text-center.mb-0 Yer
+                .d-flex.align-items-center
+                    .d-flex.col-11
+                        .col-6
+                            p.text-center.mb-0 Durak Adı
+                        .col-6
+                            p.text-center.mb-0 Yer
+                    .col-1
+                        p.text-center.mb-0 İşlem
                 .stop-list-nodes.d-flex.flex-column.gap-3.p-2
             .col-6.flex-column.gap-3.p-3.align-items-start.stop-panel
                 .input-group
@@ -709,15 +721,18 @@ block content
                     button.btn.mb-2.add-route
                         i.fa-solid.fa-plus.me-2
                         | EKLE
-                .d-flex.mb-2
-                    .col-2
-                        p.text-center.m-0 Kod
-                    .col-4
-                        p.text-center.m-0 Hat Adı
-                    .col-3
-                        p.text-center.m-0 Nereden
-                    .col-3
-                        p.text-center.m-0 Nereye
+                .d-flex.align-items-center.mb-2
+                    .d-flex.col-11
+                        .col-2
+                            p.text-center.m-0 Kod
+                        .col-4
+                            p.text-center.m-0 Hat Adı
+                        .col-3
+                            p.text-center.m-0 Nereden
+                        .col-3
+                            p.text-center.m-0 Nereye
+                    .col-1
+                        p.text-center.m-0 İşlem
                 .route-list-nodes.d-flex.flex-column.gap-3
 
             .route-info.h-100
@@ -966,35 +981,38 @@ block content
                     button.btn.mb-2.add-price
                         i.fa-solid.fa-plus.me-2
                         | EKLE
-                .d-flex.mb-2
-                    .col
-                        p.text-center.m-0 Nereden
-                    .col
-                        p.text-center.m-0 Nereye
-                    .col
-                        p.text-center.m-0 Fiyat1
-                    .col
-                        p.text-center.m-0 Fiyat2
-                    .col
-                        p.text-center.m-0 Fiyat3
-                    .col
-                        p.text-center.m-0 Webfiyat
-                    .col
-                        p.text-center.m-0 Tekli1
-                    .col
-                        p.text-center.m-0 Tekli2
-                    .col
-                        p.text-center.m-0 Tekli3
-                    .col
-                        p.text-center.m-0 Webtekli
-                    .col
-                        p.text-center.m-0 Koltuklimit
-                    .col
-                        p.text-center.m-0 Saatlimit
-                    .col
-                        p.text-center.m-0 Nezamandan
-                    .col
-                        p.text-center.m-0 Nezamana
+                .d-flex.align-items-center.mb-2
+                    .d-flex.col-11
+                        .col
+                            p.text-center.m-0 Nereden
+                        .col
+                            p.text-center.m-0 Nereye
+                        .col
+                            p.text-center.m-0 Fiyat1
+                        .col
+                            p.text-center.m-0 Fiyat2
+                        .col
+                            p.text-center.m-0 Fiyat3
+                        .col
+                            p.text-center.m-0 Webfiyat
+                        .col
+                            p.text-center.m-0 Tekli1
+                        .col
+                            p.text-center.m-0 Tekli2
+                        .col
+                            p.text-center.m-0 Tekli3
+                        .col
+                            p.text-center.m-0 Webtekli
+                        .col
+                            p.text-center.m-0 Koltuklimit
+                        .col
+                            p.text-center.m-0 Saatlimit
+                        .col
+                            p.text-center.m-0 Nezamandan
+                        .col
+                            p.text-center.m-0 Nezamana
+                    .col-1
+                        p.text-center.m-0 İşlem
                 .price-list-nodes.d-flex.flex-column.gap-3
         .p-3.d-flex.justify-content-end
             button.btn.btn-outline-primary.price-save KAYDET
@@ -1147,11 +1165,14 @@ block content
                     button.btn.mb-2.add-branch
                         i.fa-solid.fa-plus.me-2
                         | EKLE
-                .d-flex.mb-2
-                    .col-6
-                        p.text-center.m-0 Şube Adı
-                    .col-6
-                        p.text-center.m-0 Durak
+                .d-flex.align-items-center.mb-2
+                    .d-flex.col-11
+                        .col-6
+                            p.text-center.m-0 Şube Adı
+                        .col-6
+                            p.text-center.m-0 Durak
+                    .col-1
+                        p.text-center.m-0 İşlem
                 .branch-list-nodes.d-flex.flex-column.gap-3
 
             .branch-info.h-100
@@ -1210,13 +1231,16 @@ block content
                     button.btn.mb-2.add-user
                         i.fa-solid.fa-plus.me-2
                         | EKLE
-                .d-flex.mb-2
-                    .col-4
-                        p.text-center.m-0 Ad Soyad
-                    .col-4
-                        p.text-center.m-0 Şube
-                    .col-4
-                        p.text-center.m-0 Telefon
+                .d-flex.align-items-center.mb-2
+                    .d-flex.col-11
+                        .col-4
+                            p.text-center.m-0 Ad Soyad
+                        .col-4
+                            p.text-center.m-0 Şube
+                        .col-4
+                            p.text-center.m-0 Telefon
+                    .col-1
+                        p.text-center.m-0 İşlem
                 .user-list-nodes.d-flex.flex-column.gap-3
 
             .user-info.h-100

--- a/views/mixins/branchesList.pug
+++ b/views/mixins/branchesList.pug
@@ -1,13 +1,10 @@
 each b in branches
-    if b.isActive
-        button.branch-button.d-flex.btn.btn-outline-primary(data-id=b.id data-title=b.title)
+    - const btnClass = b.isActive ? 'btn-outline-primary' : 'btn-danger'
+    .btn-group.w-100
+        button.branch-button.d-flex.btn.col-11(type="button" class=btnClass data-id=b.id data-title=b.title)
             .col-6
                 p.text-center.m-0 #{b.title}
             .col-6
                 p.text-center.m-0 #{b.placeStr}
-    else
-        button.branch-button.d-flex.btn.btn-danger(data-id=b.id data-title=b.title)
-            .col-6
-                p.text-center.m-0 #{b.title}
-            .col-6
-                p.text-center.m-0 #{b.placeStr}
+        button.btn.btn-outline-danger.branch-delete.col-1(type="button" data-id=b.id data-title=b.title)
+            i.fa-solid.fa-trash

--- a/views/mixins/busesList.pug
+++ b/views/mixins/busesList.pug
@@ -1,8 +1,11 @@
 each b in buses
-    button.bus-button.d-flex.btn.btn-outline-primary(data-id=b.id data-license-plate=b.licensePlate)
-        .col-4
-            p.text-center.m-0 #{b.licensePlate}
-        .col-4
-            p.text-center.m-0 #{b.busModelStr}
-        .col-4
-            p.text-center.m-0 #{b.phoneNumber}
+    .btn-group.w-100
+        button.bus-button.d-flex.btn.btn-outline-primary.col-11(type="button" data-id=b.id data-license-plate=b.licensePlate)
+            .col-4
+                p.text-center.m-0 #{b.licensePlate}
+            .col-4
+                p.text-center.m-0 #{b.busModelStr}
+            .col-4
+                p.text-center.m-0 #{b.phoneNumber}
+        button.btn.btn-outline-danger.bus-delete.col-1(type="button" data-id=b.id data-plate=b.licensePlate)
+            i.fa-solid.fa-trash

--- a/views/mixins/pricesList.pug
+++ b/views/mixins/pricesList.pug
@@ -1,31 +1,34 @@
 p#price-stops-data #{JSON.stringify(stops)}
 each p in prices
-    .d-flex.btn.btn-outline-primary(data-id=p.id)
-        .col
-            p.text-center.m-0(data-value=p.fromStopId) #{p.fromTitle}
-        .col
-            p.text-center.m-0(data-value=p.toStopId) #{p.toTitle}
-        .col
-            p.text-center.m-0 #{p.price1}
-        .col
-            p.text-center.m-0 #{p.price2}
-        .col
-            p.text-center.m-0 #{p.price3}
-        .col
-            p.text-center.m-0 #{p.webPrice}
-        .col
-            p.text-center.m-0 #{p.singleSeatPrice1}
-        .col
-            p.text-center.m-0 #{p.singleSeatPrice2}
-        .col
-            p.text-center.m-0 #{p.singleSeatPrice3}
-        .col
-            p.text-center.m-0 #{p.singleSeatWebPrice}
-        .col
-            p.text-center.m-0 #{p.seatLimit}
-        .col
-            p.text-center.m-0(data-value=p.hourLimit) #{p.hourLimit}
-        .col
-            p.text-center.m-0(data-value=p.validFrom) #{p.validFrom}
-        .col
-            p.text-center.m-0(data-value=p.validUntil) #{p.validUntil}
+    .btn-group.w-100
+        button.price-row.d-flex.btn.btn-outline-primary.col-11(type="button" data-id=p.id data-from=p.fromTitle data-to=p.toTitle)
+            .col
+                p.text-center.m-0(data-value=p.fromStopId) #{p.fromTitle}
+            .col
+                p.text-center.m-0(data-value=p.toStopId) #{p.toTitle}
+            .col
+                p.text-center.m-0 #{p.price1}
+            .col
+                p.text-center.m-0 #{p.price2}
+            .col
+                p.text-center.m-0 #{p.price3}
+            .col
+                p.text-center.m-0 #{p.webPrice}
+            .col
+                p.text-center.m-0 #{p.singleSeatPrice1}
+            .col
+                p.text-center.m-0 #{p.singleSeatPrice2}
+            .col
+                p.text-center.m-0 #{p.singleSeatPrice3}
+            .col
+                p.text-center.m-0 #{p.singleSeatWebPrice}
+            .col
+                p.text-center.m-0 #{p.seatLimit}
+            .col
+                p.text-center.m-0(data-value=p.hourLimit) #{p.hourLimit}
+            .col
+                p.text-center.m-0(data-value=p.validFrom) #{p.validFrom}
+            .col
+                p.text-center.m-0(data-value=p.validUntil) #{p.validUntil}
+        button.btn.btn-outline-danger.price-delete.col-1(type="button" data-id=p.id data-from=p.fromTitle data-to=p.toTitle)
+            i.fa-solid.fa-trash

--- a/views/mixins/routesList.pug
+++ b/views/mixins/routesList.pug
@@ -1,10 +1,13 @@
 each r in routes
-    button.route-button.d-flex.btn.btn-outline-primary(data-id=r.id data-title=r.title)
-        .col-2
-            p.text-center.m-0 #{r.routeCode}
-        .col-4
-            p.text-center.m-0 #{r.title}
-        .col-3
-            p.text-center.m-0 #{r.fromTitle}
-        .col-3
-            p.text-center.m-0 #{r.toTitle}
+    .btn-group.w-100
+        button.route-button.d-flex.btn.btn-outline-primary.col-11(type="button" data-id=r.id data-title=r.title)
+            .col-2
+                p.text-center.m-0 #{r.routeCode}
+            .col-4
+                p.text-center.m-0 #{r.title}
+            .col-3
+                p.text-center.m-0 #{r.fromTitle}
+            .col-3
+                p.text-center.m-0 #{r.toTitle}
+        button.btn.btn-outline-danger.route-delete.col-1(type="button" data-id=r.id data-title=r.title)
+            i.fa-solid.fa-trash

--- a/views/mixins/staffList.pug
+++ b/views/mixins/staffList.pug
@@ -1,8 +1,11 @@
 each s in staff
-    button.staff-button.d-flex.btn.btn-outline-primary(data-id=s.id)
-        .col-4
-            p.text-center.m-0 #{s.idNumber}
-        .col-4
-            p.text-center.m-0 #{s.name} #{s.surname}
-        .col-4
-            p.text-center.m-0 #{s.dutyStr}
+    .btn-group.w-100
+        button.staff-button.d-flex.btn.btn-outline-primary.col-11(type="button" data-id=s.id)
+            .col-4
+                p.text-center.m-0 #{s.idNumber}
+            .col-4
+                p.text-center.m-0 #{s.name} #{s.surname}
+            .col-4
+                p.text-center.m-0 #{s.dutyStr}
+        button.btn.btn-outline-danger.staff-delete.col-1(type="button" data-id=s.id data-name=`${s.name} ${s.surname}`)
+            i.fa-solid.fa-trash

--- a/views/mixins/stopsList.pug
+++ b/views/mixins/stopsList.pug
@@ -1,6 +1,9 @@
 each s in stops
-    button.stop-button.d-flex.btn.btn-outline-primary(data-id=s.id)
-        .col-6
-            p.text-center.m-0 #{s.title}
-        .col-6
-            p.text-center.m-0 #{s.placeTitle}
+    .btn-group.w-100
+        button.stop-button.d-flex.btn.btn-outline-primary.col-11(type="button" data-id=s.id)
+            .col-6
+                p.text-center.m-0 #{s.title}
+            .col-6
+                p.text-center.m-0 #{s.placeTitle}
+        button.btn.btn-outline-danger.stop-delete.col-1(type="button" data-id=s.id data-title=s.title)
+            i.fa-solid.fa-trash

--- a/views/mixins/usersList.pug
+++ b/views/mixins/usersList.pug
@@ -1,8 +1,11 @@
 each u in users
-    button.user-button.d-flex.btn.btn-outline-primary(data-id=u.id data-username=u.username)
-        .col-4
-            p.text-center.m-0 #{u.name}
-        .col-4
-            p.text-center.m-0 #{u.branchStr}
-        .col-4
-            p.text-center.m-0 #{u.phoneNumber}
+    .btn-group.w-100
+        button.user-button.d-flex.btn.btn-outline-primary.col-11(type="button" data-id=u.id data-username=u.username data-name=u.name)
+            .col-4
+                p.text-center.m-0 #{u.name}
+            .col-4
+                p.text-center.m-0 #{u.branchStr}
+            .col-4
+                p.text-center.m-0 #{u.phoneNumber}
+        button.btn.btn-outline-danger.user-delete.col-1(type="button" data-id=u.id data-name=u.name)
+            i.fa-solid.fa-trash


### PR DESCRIPTION
## Summary
- update admin list mixins to size the selection and delete buttons with Bootstrap column classes
- wrap the branch, bus, staff, stop, route, price, user, and bus plan pop-up headers in matching column layouts
- adjust the bus plan list rendering script to emit the new column-aligned markup

## Testing
- not run (not available)


------
https://chatgpt.com/codex/tasks/task_e_68d06083c91c8322a9110ede1db26f64