### PR TITLE
Add controls to cycle ticket prices

### DIFF
--- a/controllers/erpController.js
+++ b/controllers/erpController.js
@@ -1302,7 +1302,48 @@ exports.getTicketRow = async (req, res, next) => {
         const ticketUserBranch = user ? await req.models.Branch.findOne({ where: { id: user.branchId } }) : null;
 
         const gender = ticket.map((t) => t.gender);
-        return res.render("mixins/ticketRow", { gender, seats: seatNumbers, ticket, trip, isOwnBranch, seatTypes, action });
+
+        let pricesForTickets = [];
+
+        if (ticket.length) {
+            const routeStopIds = ticket.reduce((ids, t) => {
+                if (t.fromRouteStopId) ids.add(t.fromRouteStopId);
+                if (t.toRouteStopId) ids.add(t.toRouteStopId);
+                return ids;
+            }, new Set());
+
+            const routeStops = routeStopIds.size
+                ? await req.models.RouteStop.findAll({ where: { id: { [Op.in]: Array.from(routeStopIds) } } })
+                : [];
+
+            const routeStopMap = routeStops.reduce((acc, rs) => {
+                acc[rs.id] = rs.stopId;
+                return acc;
+            }, {});
+
+            const priceCache = {};
+
+            for (const t of ticket) {
+                const fromStopId = routeStopMap[t.fromRouteStopId];
+                const toStopId = routeStopMap[t.toRouteStopId];
+
+                let priceForSeat = null;
+
+                if (fromStopId && toStopId) {
+                    const key = `${fromStopId}-${toStopId}`;
+
+                    if (!(key in priceCache)) {
+                        priceCache[key] = await req.models.Price.findOne({ where: { fromStopId, toStopId } });
+                    }
+
+                    priceForSeat = priceCache[key];
+                }
+
+                pricesForTickets.push(priceForSeat);
+            }
+        }
+
+        return res.render("mixins/ticketRow", { gender, seats: seatNumbers, ticket, trip, isOwnBranch, seatTypes, action, price: pricesForTickets });
     }
 
     // --- ELSE CASE ---

--- a/public/scripts/erp.js
+++ b/public/scripts/erp.js
@@ -19,6 +19,157 @@ let accountCutId;
 let originalPrices = []
 let seatTypes = []
 
+function parsePriceAttribute(value) {
+    if (value === undefined || value === null || value === "") {
+        return [];
+    }
+
+    if (Array.isArray(value)) {
+        return value
+            .map(v => Number(v))
+            .filter(v => !Number.isNaN(v));
+    }
+
+    if (typeof value === "number") {
+        return Number.isNaN(value) ? [] : [value];
+    }
+
+    if (typeof value === "string") {
+        const trimmed = value.trim();
+
+        if (!trimmed) {
+            return [];
+        }
+
+        try {
+            const parsed = JSON.parse(trimmed);
+
+            if (Array.isArray(parsed)) {
+                return parsed
+                    .map(v => Number(v))
+                    .filter(v => !Number.isNaN(v));
+            }
+
+            if (typeof parsed === "number" && !Number.isNaN(parsed)) {
+                return [parsed];
+            }
+
+            return [];
+        } catch (err) {
+            return trimmed
+                .split(",")
+                .map(part => Number(part.trim()))
+                .filter(v => !Number.isNaN(v));
+        }
+    }
+
+    return [];
+}
+
+function getPriceLists($priceContainer) {
+    const seatType = $priceContainer.attr("data-seat-type") === "single" ? "single" : "standard";
+    const regularPrices = parsePriceAttribute($priceContainer.attr("data-regular-prices"));
+    const singlePrices = parsePriceAttribute($priceContainer.attr("data-single-prices"));
+
+    const activeList = seatType === "single"
+        ? (singlePrices.length ? singlePrices : regularPrices)
+        : (regularPrices.length ? regularPrices : singlePrices);
+
+    return {
+        seatType,
+        regularPrices,
+        singlePrices,
+        activeList,
+    };
+}
+
+function initializeTicketRowPriceControls() {
+    originalPrices = [];
+
+    $(".ticket-row").each((index, row) => {
+        const $row = $(row);
+        const $priceInput = $row.find(".price input").first();
+        const basePrice = Number($priceInput.val());
+
+        originalPrices[index] = Number.isNaN(basePrice) ? null : basePrice;
+    });
+}
+
+$(document).on("click", ".price-arrow", function (e) {
+    e.preventDefault();
+
+    const $button = $(this);
+    const isUp = $button.hasClass("price-arrow-up");
+    const $priceContainer = $button.closest(".price");
+    const priceLists = getPriceLists($priceContainer);
+    const options = priceLists.activeList;
+
+    if (!options.length) {
+        return;
+    }
+
+    const $row = $button.closest(".ticket-row");
+    const rowIndex = $(".ticket-row").index($row);
+    const $input = $priceContainer.find("input").first();
+
+    const currentValue = Number($input.val());
+    let currentIndex = options.findIndex(p => Number(p) === currentValue);
+
+    if (currentIndex === -1 && rowIndex > -1) {
+        const originalPrice = originalPrices[rowIndex];
+
+        if (originalPrice !== undefined && originalPrice !== null) {
+            currentIndex = options.findIndex(p => Number(p) === Number(originalPrice));
+        }
+    }
+
+    let nextIndex;
+
+    if (currentIndex === -1) {
+        nextIndex = isUp ? 0 : options.length - 1;
+    } else if (isUp) {
+        nextIndex = (currentIndex + 1) % options.length;
+    } else {
+        nextIndex = (currentIndex - 1 + options.length) % options.length;
+    }
+
+    const newBasePrice = Number(options[nextIndex]);
+
+    if (Number.isNaN(newBasePrice)) {
+        return;
+    }
+
+    if (rowIndex > -1) {
+        originalPrices[rowIndex] = newBasePrice;
+    }
+
+    let finalPrice = newBasePrice;
+    const $discountInfo = $priceContainer.find("span.customer-point");
+    const pointOrPercent = $discountInfo.data("pointorpercent");
+
+    if (pointOrPercent === "percent") {
+        const percentText = ($discountInfo.text() || "").trim();
+        const percentMatch = percentText.match(/-?\d+(?:[.,]\d+)?/);
+
+        if (percentMatch) {
+            const percentValue = parseFloat(percentMatch[0].replace(",", "."));
+
+            if (!Number.isNaN(percentValue)) {
+                finalPrice = newBasePrice - ((newBasePrice / 100) * percentValue);
+            }
+        }
+    }
+
+    $input.val(finalPrice);
+
+    if ($input.length && $input[0]) {
+        const inputEvent = new Event("input", { bubbles: true });
+        const changeEvent = new Event("change", { bubbles: true });
+        $input[0].dispatchEvent(inputEvent);
+        $input[0].dispatchEvent(changeEvent);
+    }
+});
+
 let tripStaffInitial = {};
 let tripStaffList = [];
 
@@ -1219,10 +1370,7 @@ async function loadTrip(date, time, tripId) {
 
                         initTcknInputs(".identity input")
                         initPhoneInput(".phone input")
-
-                        $(".ticket-row").each((i, e) => {
-                            originalPrices[i] = Number($(".ticket-row").find(".price").find("input").val())
-                        })
+                        initializeTicketRowPriceControls()
                         $(".identity input").on("blur", async e => {
                             const customer = await $.ajax({ url: "/get-customer", type: "GET", data: { idNumber: e.currentTarget.value } });
                             if (customer) {
@@ -2098,6 +2246,7 @@ $(".taken-ticket-op").on("click", async e => {
 
                 initTcknInputs(".identity input")
                 initPhoneInput(".phone input")
+                initializeTicketRowPriceControls()
 
                 $(".identity input").on("blur", async e => {
                     const customer = await $.ajax({ url: "/get-customer", type: "GET", data: { idNumber: e.currentTarget.value } });
@@ -2177,6 +2326,7 @@ $(".taken-ticket-op").on("click", async e => {
 
                 initTcknInputs(".identity input")
                 initPhoneInput(".phone input")
+                initializeTicketRowPriceControls()
 
                 $(".identity input").on("blur", async e => {
                     const customer = await $.ajax({ url: "/get-customer", type: "GET", data: { idNumber: e.currentTarget.value } });
@@ -2815,6 +2965,7 @@ $(".open-ticket-next").on("click", async e => {
             $(".ticket-rows").prepend(response)
             initTcknInputs(".identity input")
             initPhoneInput(".phone input")
+            initializeTicketRowPriceControls()
             $(".identity input").on("blur", async e => {
                 const customer = await $.ajax({ url: "/get-customer", type: "GET", data: { idNumber: e.currentTarget.value } });
                 if (customer) {

--- a/public/stylesheets/erpscreen.css
+++ b/public/stylesheets/erpscreen.css
@@ -1349,6 +1349,24 @@ div.ticket-cancel-refund-open-close {
     border-radius: .3rem;
 }
 
+.ticket-row .price-input-wrapper {
+    display: flex;
+    align-items: center;
+    gap: .25rem;
+}
+
+.ticket-row .price-arrows {
+    display: flex;
+    flex-direction: column;
+    gap: .25rem;
+}
+
+.ticket-row .price-arrows .btn {
+    line-height: 1;
+    padding: .25rem .35rem;
+    min-width: 0;
+}
+
 .gender input[type="radio"]:checked+label.male {
     background-color: #21639650;
     border-color: #216396;

--- a/views/mixins/ticketRow.pug
+++ b/views/mixins/ticketRow.pug
@@ -42,22 +42,41 @@
             label.form-label Kategori
             select.form-select.form-select-sm(value=ticket?ticket[i].customerCategory:"")
                 option(value="normal") Normal
-                if (permissions.includes('SALE_DISCOUNT_TICKET_OWN_BRANCH') && isOwnBranch) || (permissions.includes('SALE_DISCOUNT_TICKET_OTHER_BRANCH') && !isOwnBranch) 
+                if (permissions.includes('SALE_DISCOUNT_TICKET_OWN_BRANCH') && isOwnBranch) || (permissions.includes('SALE_DISCOUNT_TICKET_OTHER_BRANCH') && !isOwnBranch)
                     option(value="member") Abone
                     option(value="guest") Misafir
-        .price
-            label.form-label Fiyat 
+        - const seatPriceData = Array.isArray(price) ? price[i] : price;
+        - const seatType = seatTypes && seatTypes[i] == "single" ? "single" : "standard";
+        - const regularPriceValues = [];
+        - const singleSeatPriceValues = [];
+        - if (seatPriceData && typeof seatPriceData === "object") {
+        -     if (seatPriceData.price1 !== undefined && seatPriceData.price1 !== null) regularPriceValues.push(seatPriceData.price1);
+        -     if (seatPriceData.price2 !== undefined && seatPriceData.price2 !== null) regularPriceValues.push(seatPriceData.price2);
+        -     if (seatPriceData.price3 !== undefined && seatPriceData.price3 !== null) regularPriceValues.push(seatPriceData.price3);
+        -     if (seatPriceData.singleSeatPrice1 !== undefined && seatPriceData.singleSeatPrice1 !== null) singleSeatPriceValues.push(seatPriceData.singleSeatPrice1);
+        -     if (seatPriceData.singleSeatPrice2 !== undefined && seatPriceData.singleSeatPrice2 !== null) singleSeatPriceValues.push(seatPriceData.singleSeatPrice2);
+        -     if (seatPriceData.singleSeatPrice3 !== undefined && seatPriceData.singleSeatPrice3 !== null) singleSeatPriceValues.push(seatPriceData.singleSeatPrice3);
+        - }
+        - const activePriceList = seatType === "single"
+        -     ? (singleSeatPriceValues.length ? singleSeatPriceValues : regularPriceValues)
+        -     : (regularPriceValues.length ? regularPriceValues : singleSeatPriceValues);
+        - const defaultPriceValue = ticket && ticket[i] ? ticket[i].price : (activePriceList.length ? activePriceList[0] : "");
+        - const showPriceArrows = activePriceList.length > 1;
+        .price(data-seat-type=seatType data-regular-prices=JSON.stringify(regularPriceValues) data-single-prices=JSON.stringify(singleSeatPriceValues))
+            label.form-label
+                | Fiyat
                 span.customer-point.ms-1
-            if !permissions.includes('ENTER_FREE_PRICE')
-                if seatTypes &&seatTypes[i] == "single"
-                    input.form-control.form-control-sm(readonly type="number" name="" value=ticket?ticket[i].price:price.singleSeatPrice1)
+            .price-input-wrapper
+                if !permissions.includes('ENTER_FREE_PRICE')
+                    input.form-control.form-control-sm(readonly type="number" name="" value=defaultPriceValue)
                 else
-                    input.form-control.form-control-sm(readonly type="number" name="" value=ticket?ticket[i].price:price.price1)
-            else 
-                if seatTypes &&seatTypes[i] == "single"
-                    input.form-control.form-control-sm(type="number" name="" value=ticket?ticket[i].price:price.singleSeatPrice1)
-                else
-                    input.form-control.form-control-sm(type="number" name="" value=ticket?ticket[i].price:price.price1)
+                    input.form-control.form-control-sm(type="number" name="" value=defaultPriceValue)
+                if showPriceArrows
+                    .price-arrows.btn-group-vertical.ms-1
+                        button.price-arrow.price-arrow-up.btn.btn-outline-secondary.btn-sm(type="button")
+                            i.fa-solid.fa-chevron-up
+                        button.price-arrow.price-arrow-down.btn.btn-outline-secondary.btn-sm(type="button")
+                            i.fa-solid.fa-chevron-down
 -}
 .ticket-info    
     .up-row


### PR DESCRIPTION
## Summary
- add up/down arrows next to ticket row prices and expose available seat-specific price options
- cycle prices client-side while tracking base amounts and reapplying percentage discounts
- load price data for taken tickets and style the new controls for the ticket form

## Testing
- Not run (not available)

------
https://chatgpt.com/codex/tasks/task_e_68d14faf87088322abfa07c046ec1a30