### PR TITLE
Add bus feature fields and sync with bus model

### DIFF
--- a/controllers/erpController.js
+++ b/controllers/erpController.js
@@ -2590,7 +2590,30 @@ exports.postSaveBus = async (req, res, next) => {
 
         const data = convertEmptyFieldsToNull(req.body);
 
-        const { id, licensePlate, busModelId, captainId, phoneNumber, owner } = data;
+        const {
+            id,
+            licensePlate,
+            busModelId,
+            captainId,
+            phoneNumber,
+            owner,
+            hasPowerOutlet,
+            hasCatering,
+            hasUsbPort,
+            hasSeatScreen,
+            hasComfortableSeat,
+            hasFridge,
+            hasWifi,
+            hasSeatPillow
+        } = data;
+
+        const parseBoolean = value => {
+            if (typeof value === "string") {
+                const lowered = value.toLowerCase();
+                return lowered === "true" || lowered === "1" || lowered === "on";
+            }
+            return Boolean(value);
+        };
 
         const [bus, created] = await req.models.Bus.upsert(
             {
@@ -2599,7 +2622,15 @@ exports.postSaveBus = async (req, res, next) => {
                 busModelId,
                 captainId,
                 phoneNumber,
-                owner
+                owner,
+                hasPowerOutlet: parseBoolean(hasPowerOutlet),
+                hasCatering: parseBoolean(hasCatering),
+                hasUsbPort: parseBoolean(hasUsbPort),
+                hasSeatScreen: parseBoolean(hasSeatScreen),
+                hasComfortableSeat: parseBoolean(hasComfortableSeat),
+                hasFridge: parseBoolean(hasFridge),
+                hasWifi: parseBoolean(hasWifi),
+                hasSeatPillow: parseBoolean(hasSeatPillow)
             },
             { returning: true }
         );

--- a/models/busModel.js
+++ b/models/busModel.js
@@ -27,5 +27,45 @@ module.exports = (sequelize) => {
       type: DataTypes.STRING,
       allowNull: true,
     },
+    hasPowerOutlet: {
+      type: DataTypes.BOOLEAN,
+      allowNull: false,
+      defaultValue: false,
+    },
+    hasCatering: {
+      type: DataTypes.BOOLEAN,
+      allowNull: false,
+      defaultValue: false,
+    },
+    hasUsbPort: {
+      type: DataTypes.BOOLEAN,
+      allowNull: false,
+      defaultValue: false,
+    },
+    hasSeatScreen: {
+      type: DataTypes.BOOLEAN,
+      allowNull: false,
+      defaultValue: false,
+    },
+    hasComfortableSeat: {
+      type: DataTypes.BOOLEAN,
+      allowNull: false,
+      defaultValue: false,
+    },
+    hasFridge: {
+      type: DataTypes.BOOLEAN,
+      allowNull: false,
+      defaultValue: false,
+    },
+    hasWifi: {
+      type: DataTypes.BOOLEAN,
+      allowNull: false,
+      defaultValue: false,
+    },
+    hasSeatPillow: {
+      type: DataTypes.BOOLEAN,
+      allowNull: false,
+      defaultValue: false,
+    },
   });
 };

--- a/public/scripts/erp.js
+++ b/public/scripts/erp.js
@@ -3713,6 +3713,48 @@ $(".add-bus-plan").on("click", async e => {
     })
 })
 
+const BUS_FEATURE_SELECTOR = ".bus-feature"
+
+function setBusFeatureValues(bus = {}) {
+    $(BUS_FEATURE_SELECTOR).each((_, el) => {
+        const field = el.dataset.field
+        if (!field) return
+        const value = bus[field]
+        if (value === undefined || value === null) {
+            if (typeof el.defaultChecked === "boolean") {
+                el.checked = el.defaultChecked
+            }
+            else {
+                el.checked = false
+            }
+        }
+        else {
+            el.checked = Boolean(value)
+        }
+    })
+}
+
+function resetBusFeatureDefaults() {
+    $(BUS_FEATURE_SELECTOR).each((_, el) => {
+        if (typeof el.defaultChecked === "boolean") {
+            el.checked = el.defaultChecked
+        }
+        else {
+            el.checked = false
+        }
+    })
+}
+
+function collectBusFeatureValues() {
+    const result = {}
+    $(BUS_FEATURE_SELECTOR).each((_, el) => {
+        const field = el.dataset.field
+        if (!field) return
+        result[field] = el.checked ? "true" : "false"
+    })
+    return result
+}
+
 let editingBusId = null
 
 setupDeleteHandler(".bus-delete", {
@@ -3790,6 +3832,7 @@ $(".bus-nav").on("click", async e => {
                         $(".bus-captain").val(response.captainId)
                         $(".bus-phone").val(response.phoneNumber)
                         $(".bus-owner").val(response.owner)
+                        setBusFeatureValues(response || {})
                         $(".bus").css("width", "75vw")
                         $(".bus-list").removeClass("col-12").addClass("col-4")
                         $(".bus-info").css("display", "flex")
@@ -3829,6 +3872,7 @@ $(".add-bus").on("click", e => {
     $(".bus-captain").val("")
     $(".bus-phone").val("")
     $(".bus-owner").val("")
+    resetBusFeatureDefaults()
     editingBusId = null
     $(".bus").css("width", "75vw")
     $(".bus-list").removeClass("col-12").addClass("col-4")
@@ -3843,17 +3887,19 @@ $(".save-bus").on("click", async e => {
     const captainId = $(".bus-captain").val()
     const phoneNumber = $(".bus-phone").val()
     const owner = $(".bus-owner").val()
+    const featureData = collectBusFeatureValues()
 
     await $.ajax({
         url: "/post-save-bus",
         type: "POST",
-        data: { id: editingBusId, licensePlate, busModelId, captainId, phoneNumber, owner },
+        data: { id: editingBusId, licensePlate, busModelId, captainId, phoneNumber, owner, ...featureData },
         success: function (response) {
             $(".bus-license-plate").val("")
             $(".bus-bus-model").val("")
             $(".bus-captain").val("")
             $(".bus-phone").val("")
             $(".bus-owner").val("")
+            resetBusFeatureDefaults()
             editingBusId = null
             $(".bus").css("width", "30vw")
             $(".bus-list").addClass("col-12").removeClass("col-4")

--- a/views/erpscreen.pug
+++ b/views/erpscreen.pug
@@ -585,29 +585,29 @@ block content
                 b Özellikler
                 .ms-3.mb-3
                     .form-check
-                        input#flexCheckChecked.form-check-input(type="checkbox" value="" checked)
-                        label.form-check-label(for="flexCheckChecked") Araçta priz bulunmakta
+                        input#bus-feature-power-outlet.form-check-input.bus-feature(type="checkbox" data-field="hasPowerOutlet" checked)
+                        label.form-check-label(for="bus-feature-power-outlet") Araçta priz bulunmakta
                     .form-check
-                        input#flexCheckChecked.form-check-input(type="checkbox" value="" checked)
-                        label.form-check-label(for="flexCheckChecked") Araçta ikram yapılmakta
+                        input#bus-feature-catering.form-check-input.bus-feature(type="checkbox" data-field="hasCatering" checked)
+                        label.form-check-label(for="bus-feature-catering") Araçta ikram yapılmakta
                     .form-check
-                        input#flexCheckChecked.form-check-input(type="checkbox" value="" checked)
-                        label.form-check-label(for="flexCheckChecked") Araçta USB ile bağlantı mevcut
+                        input#bus-feature-usb.form-check-input.bus-feature(type="checkbox" data-field="hasUsbPort" checked)
+                        label.form-check-label(for="bus-feature-usb") Araçta USB ile bağlantı mevcut
                     .form-check
-                        input#flexCheckChecked.form-check-input(type="checkbox" value="" checked)
-                        label.form-check-label(for="flexCheckChecked") Koltuk arkasında ekran var
+                        input#bus-feature-seat-screen.form-check-input.bus-feature(type="checkbox" data-field="hasSeatScreen" checked)
+                        label.form-check-label(for="bus-feature-seat-screen") Koltuk arkasında ekran var
                     .form-check
-                        input#flexCheckChecked.form-check-input(type="checkbox" value="" checked)
-                        label.form-check-label(for="flexCheckChecked") Koltuklar geniş ve konforlu
+                        input#bus-feature-comfort-seat.form-check-input.bus-feature(type="checkbox" data-field="hasComfortableSeat" checked)
+                        label.form-check-label(for="bus-feature-comfort-seat") Koltuklar geniş ve konforlu
                     .form-check
-                        input#flexCheckChecked.form-check-input(type="checkbox" value="" checked)
-                        label.form-check-label(for="flexCheckChecked") Soğuk içecekler için dolap var
+                        input#bus-feature-fridge.form-check-input.bus-feature(type="checkbox" data-field="hasFridge" checked)
+                        label.form-check-label(for="bus-feature-fridge") Soğuk içecekler için dolap var
                     .form-check
-                        input#flexCheckChecked.form-check-input(type="checkbox" value="" checked)
-                        label.form-check-label(for="flexCheckChecked") Ücretsiz Wi-Fi mevcut
+                        input#bus-feature-wifi.form-check-input.bus-feature(type="checkbox" data-field="hasWifi" checked)
+                        label.form-check-label(for="bus-feature-wifi") Ücretsiz Wi-Fi mevcut
                     .form-check
-                        input#flexCheckChecked.form-check-input(type="checkbox" value="" checked)
-                        label.form-check-label(for="flexCheckChecked") Koltuk yastıkları mevcut
+                        input#bus-feature-seat-pillow.form-check-input.bus-feature(type="checkbox" data-field="hasSeatPillow" checked)
+                        label.form-check-label(for="bus-feature-seat-pillow") Koltuk yastıkları mevcut
 
     .staff
         .staff-close


### PR DESCRIPTION
## Summary
- add boolean feature fields to the bus Sequelize model so amenities are persisted
- capture amenity selections from the ERP bus form and include them in save requests
- render unique amenity checkboxes that are synced with stored values when editing a bus

## Testing
- not run (not provided)


------
https://chatgpt.com/codex/tasks/task_e_68d3ff690a8c8322a29a6137f16c12f8