### PR TITLE
Add trip seat plan passenger report

### DIFF
--- a/public/scripts/erp.js
+++ b/public/scripts/erp.js
@@ -1865,6 +1865,16 @@ async function loadTrip(date, time, tripId) {
                 window.open(`/get-bus-account-cut-receipt?tripId=${currentTripId}&stopId=${currentStop}`, "_blank", "width=800,height=600");
             });
 
+            $(".trip-seat-plan-report").on("click", e => {
+                e.preventDefault();
+                if (!currentTripId) return;
+                const params = new URLSearchParams({ tripId: currentTripId });
+                if (currentStop !== undefined && currentStop !== null && currentStop !== "") {
+                    params.append("stopId", currentStop);
+                }
+                window.open(`/trip-seat-plan?${params.toString()}`, "_blank", "width=900,height=700");
+            });
+
             $(".account-cut-undo").off().on("click", async () => {
                 try {
                     const data = await $.ajax({

--- a/routes/erp.js
+++ b/routes/erp.js
@@ -40,6 +40,7 @@ router.post('/post-bus-account-cut', auth, erpController.postBusAccountCut);
 router.get('/get-bus-account-cut-record', auth, erpController.getBusAccountCutRecord);
 router.post('/post-delete-bus-account-cut', auth, erpController.postDeleteBusAccountCut);
 router.get('/get-bus-account-cut-receipt', auth, erpController.getBusAccountCutReceipt);
+router.get('/trip-seat-plan', auth, erpController.getTripSeatPlanReport);
 
 router.get('/get-ticketops-popup', erpController.getTicketOpsPopUp);
 

--- a/utilities/reports/tripSeatPlanReport.js
+++ b/utilities/reports/tripSeatPlanReport.js
@@ -1,0 +1,264 @@
+const PDFDocument = require('pdfkit');
+const fs = require('fs');
+const path = require('path');
+
+const GENDER_LABELS = {
+  f: 'Kadın',
+  m: 'Erkek',
+};
+
+const STATUS_LABELS = {
+  reservation: 'Rez',
+  web: 'WEB',
+  gotur: 'Götür',
+  completed: 'Satış',
+  open: 'Açık',
+};
+
+const PAYMENT_LABELS = {
+  cash: 'Nakit',
+  card: 'K.Kartı',
+  point: 'Puan',
+};
+
+const currencyFormatter = new Intl.NumberFormat('tr-TR', {
+  minimumFractionDigits: 2,
+  maximumFractionDigits: 2,
+});
+
+const seatPriceFormatter = new Intl.NumberFormat('tr-TR', {
+  minimumFractionDigits: 0,
+  maximumFractionDigits: 2,
+});
+
+const formatCurrency = (value) => {
+  const amount = Number(value);
+  if (!Number.isFinite(amount)) {
+    return '0,00 TL';
+  }
+  return `${currencyFormatter.format(amount)} TL`;
+};
+
+const formatSeatPrice = (value) => {
+  const amount = Number(value);
+  if (!Number.isFinite(amount) || amount === 0) {
+    return '';
+  }
+  return seatPriceFormatter.format(amount);
+};
+
+const toUpper = (value) => (value ? value.toLocaleUpperCase('tr-TR') : '');
+
+function registerFonts(doc) {
+  const regularFontPath = path.join(__dirname, 'fonts', 'DejaVuSans.ttf');
+  const boldFontPath = path.join(__dirname, 'fonts', 'DejaVuSans-Bold.ttf');
+
+  try {
+    doc.registerFont('Regular', regularFontPath);
+    doc.registerFont('Bold', boldFontPath);
+    doc.font('Regular');
+  } catch (err) {
+    console.warn('Font yüklenemedi, varsayılan font kullanılacak:', err.message);
+  }
+}
+
+function drawHeader(doc, header) {
+  const leftColumn = [
+    { label: 'Kalkış Saati', value: header?.departure || '' },
+    { label: 'Plaka No', value: header?.plate || '' },
+    { label: 'Varış', value: header?.arrival || '' },
+  ];
+
+  const rightColumn = [
+    { label: 'Otobüs Sahibi', value: header?.owner || '' },
+    { label: 'Vergi Dairesi', value: header?.taxOffice || '' },
+    { label: 'Vergi Numarası', value: header?.taxNumber || '' },
+  ];
+
+  const leftX = doc.page.margins.left;
+  const rightX = doc.page.width / 2 + 10;
+  let y = doc.page.margins.top;
+
+  doc.fontSize(9);
+  leftColumn.forEach((item, index) => {
+    const rowY = y + index * 16;
+    doc.font('Bold').text(`${item.label} : `, leftX, rowY, { continued: true });
+    doc.font('Regular').text(item.value || '');
+  });
+
+  rightColumn.forEach((item, index) => {
+    const rowY = y + index * 16;
+    doc.font('Bold').text(`${item.label} : `, rightX, rowY, { continued: true });
+    doc.font('Regular').text(item.value || '');
+  });
+
+  const centerY = y + leftColumn.length * 16 + 6;
+  const routeTitle = toUpper(header?.route || '');
+  const routeCode = header?.routeCode ? ` (${header.routeCode})` : '';
+  const modelTitle = header?.busModel ? ` • ${header.busModel}` : '';
+
+  doc.font('Bold').fontSize(13).text(`${routeTitle}${routeCode}${modelTitle}`, leftX, centerY, {
+    width: doc.page.width - doc.page.margins.left - doc.page.margins.right,
+    align: 'center',
+  });
+
+  const driverLine = header?.driver ? `Şoför: ${header.driver}` : '';
+  if (driverLine) {
+    doc.font('Regular').fontSize(9).text(driverLine, {
+      width: doc.page.width - doc.page.margins.left - doc.page.margins.right,
+      align: 'center',
+    });
+  }
+
+  doc.moveDown(1.2);
+}
+
+function drawSeat(doc, x, y, width, height, seatNumber, seatInfo, options) {
+  const padding = 4;
+  const innerWidth = width - padding * 2;
+
+  if (seatInfo && options?.highlightByStop) {
+    doc.save();
+    doc.rect(x, y, width, height);
+    doc.fillColor(seatInfo.isCurrentStop ? '#f6fbff' : '#f2f2f2').fill();
+    doc.restore();
+  }
+
+  doc.rect(x, y, width, height).stroke();
+
+  doc.font('Bold').fontSize(9).fillColor('black').text(String(seatNumber), x + padding, y + padding, {
+    width: innerWidth,
+  });
+
+  if (seatInfo) {
+    const seatPrice = formatSeatPrice(seatInfo.price);
+    if (seatPrice) {
+      doc.font('Bold').fontSize(9).text(seatPrice, x + padding, y + padding, {
+        width: innerWidth,
+        align: 'right',
+      });
+    }
+
+    let cursorY = y + padding + 12;
+
+    const statusBadge = STATUS_LABELS[seatInfo.status];
+    const paymentBadge = PAYMENT_LABELS[seatInfo.payment];
+    const badges = [statusBadge, paymentBadge].filter(Boolean).join(' • ');
+    if (badges) {
+      doc.font('Bold').fontSize(7).text(badges, x + padding, cursorY, {
+        width: innerWidth,
+        align: 'left',
+      });
+      cursorY += doc.heightOfString(badges, { width: innerWidth }) + 2;
+    }
+
+    const name = seatInfo.name || '';
+    if (name) {
+      doc.font('Regular').fontSize(8).text(name, x + padding, cursorY, {
+        width: innerWidth,
+        align: 'left',
+      });
+      cursorY += doc.heightOfString(name, { width: innerWidth }) + 2;
+    }
+
+    const routeLabel = [seatInfo.from, seatInfo.to].filter(Boolean).join(' → ');
+    if (routeLabel) {
+      doc.font('Regular').fontSize(7).text(routeLabel, x + padding, cursorY, {
+        width: innerWidth,
+        align: 'left',
+      });
+      cursorY += doc.heightOfString(routeLabel, { width: innerWidth }) + 2;
+    }
+
+    const genderLabel = GENDER_LABELS[seatInfo.gender];
+    const infoLine = [genderLabel, seatInfo.pnr ? `PNR: ${seatInfo.pnr}` : '']
+      .filter(Boolean)
+      .join(' • ');
+    if (infoLine) {
+      doc.font('Regular').fontSize(6.5).fillColor('#333333').text(infoLine, x + padding, cursorY, {
+        width: innerWidth,
+        align: 'left',
+      });
+      doc.fillColor('black');
+    }
+  }
+}
+
+function drawSeatLayout(doc, layout) {
+  const plan = Array.isArray(layout?.plan) ? layout.plan : [];
+  const columns = layout?.columns || 5;
+  const rows = Math.ceil(plan.length / columns) || 0;
+  if (!rows || !columns) {
+    return;
+  }
+
+  const gapX = 8;
+  const gapY = 8;
+  const usableWidth = doc.page.width - doc.page.margins.left - doc.page.margins.right;
+  const baseWidth = (usableWidth - gapX * (columns - 1)) / columns;
+  const seatWidth = Math.min(baseWidth, 60);
+  const seatHeight = Math.max(Math.min(seatWidth * 0.5, 34), 28);
+  const layoutWidth = columns * seatWidth + gapX * (columns - 1);
+  const startX = doc.page.margins.left + (usableWidth - layoutWidth) / 2;
+  const startY = doc.y;
+
+  let seatNumber = 0;
+
+  for (let row = 0; row < rows; row++) {
+    for (let col = 0; col < columns; col++) {
+      const index = row * columns + col;
+      const hasSeat = plan[index] === 1 || plan[index] === '1';
+      if (!hasSeat) {
+        continue;
+      }
+
+      seatNumber += 1;
+      const x = startX + col * (seatWidth + gapX);
+      const y = startY + row * (seatHeight + gapY);
+      const seatInfo = layout?.seats ? layout.seats[seatNumber] : null;
+      drawSeat(doc, x, y, seatWidth, seatHeight, seatNumber, seatInfo, layout);
+    }
+  }
+
+  doc.y = startY + rows * (seatHeight + gapY);
+}
+
+function drawFooter(doc, footer) {
+  if (!footer) {
+    return;
+  }
+  const label = footer?.label ? toUpper(footer.label) : '';
+  const count = Number(footer?.count) || 0;
+  const amountText = formatCurrency(footer?.amount || 0);
+
+  const summaryText = `${label ? `${label} ` : ''}Toplam Yolcu: ${count}   Toplam Tutar: ${amountText}`;
+
+  doc.moveDown(1);
+  doc.font('Bold').fontSize(10).text(summaryText, {
+    width: doc.page.width - doc.page.margins.left - doc.page.margins.right,
+    align: 'left',
+  });
+}
+
+function generateTripSeatPlanReport(data, output) {
+  const doc = new PDFDocument({ size: 'A4', margin: 36 });
+  const stream = typeof output === 'string'
+    ? fs.createWriteStream(output, { flags: 'w' })
+    : output;
+
+  doc.pipe(stream);
+  registerFonts(doc);
+
+  drawHeader(doc, data?.header || {});
+  drawSeatLayout(doc, data?.layout || {});
+  drawFooter(doc, data?.footer || {});
+
+  doc.end();
+
+  return new Promise((resolve, reject) => {
+    stream.on('finish', resolve);
+    stream.on('error', reject);
+  });
+}
+
+module.exports = generateTripSeatPlanReport;

--- a/views/mixins/busPlan.pug
+++ b/views/mixins/busPlan.pug
@@ -70,6 +70,9 @@
                 if trip.isAccountCut
                     li
                         a.dropdown-item.accountCut(href="#") Hesap Fişi
+                if trip.isAccountCut || permissions.includes('PRINT_SEAT_PLAN_INVOICE_WITHOUT_CUT')
+                    li
+                        a.dropdown-item.trip-seat-plan-report(href="#") Koltuk Planlı Yolcu Listesi
     p.text-center.m-0 #{route.routeCode} | #{trip.dateString} - #{trip.timeString}
     p.m-0.text-center
         b


### PR DESCRIPTION
## Summary
- add an ERP endpoint that normalizes trip seat plans and streams a seat-plan passenger list PDF
- implement the PDF generator to draw seat grid cells with passenger details and totals
- surface the new report from the ERP UI via the trip documents dropdown and client-side handler

## Testing
- node -e "require('./utilities/reports/tripSeatPlanReport');"
- node -e "require('./controllers/erpController.js');"

------
https://chatgpt.com/codex/tasks/task_e_68d687cb3a608322adfbd64261d847b6