### PR TITLE
Include cargo revenue in bus account cuts

### DIFF
--- a/views/mixins/busPlan.pug
+++ b/views/mixins/busPlan.pug
@@ -37,6 +37,10 @@
                         input.form-control.form-control-sm(type="text" readonly value=incomes.totalReservedCount)
                         input.form-control.form-control-sm(type="text" readonly value=`${incomes.totalReservedAmount}₺`)
                     .input-group
+                        span.input-group-text.col-7 Kargo
+                        input.form-control.form-control-sm(type="text" readonly value=incomes.cargoCount)
+                        input.form-control.form-control-sm(type="text" readonly value=`${incomes.cargoAmount}₺`)
+                    .input-group
                         span.input-group-text.col-7 Toplam
                         input.form-control.form-control-sm(type="text" readonly value=incomes.grandCount)
                         input.form-control.form-control-sm(type="text" readonly value=`${incomes.grandAmount}₺`)


### PR DESCRIPTION
## Summary
- include cargo sales when calculating bus account cut totals and stored records
- surface cargo totals in the trip income tooltip and account cut receipt so UI matches the revised calculations
- ensure deleting a bus account cut removes the record after reversing the related transactions

## Testing
- not run (not provided)


------
https://chatgpt.com/codex/tasks/task_e_68d7d517e5e08322886168b09266ffac