### PR TITLE
feat: add route settings tab and enforce seat limits

### DIFF
--- a/models/routeModel.js
+++ b/models/routeModel.js
@@ -27,5 +27,21 @@ module.exports = (sequelize) => {
       type: DataTypes.BIGINT,
       allowNull: false,
     },
+    reservationOptionTime: {
+      type: DataTypes.TIME,
+      allowNull: true,
+    },
+    refundTransferOptionTime: {
+      type: DataTypes.TIME,
+      allowNull: true,
+    },
+    maxReservationCount: {
+      type: DataTypes.INTEGER,
+      allowNull: true,
+    },
+    maxSingleSeatCount: {
+      type: DataTypes.INTEGER,
+      allowNull: true,
+    },
   });
 };

--- a/public/stylesheets/erpscreen.css
+++ b/public/stylesheets/erpscreen.css
@@ -553,6 +553,41 @@ select.price-button-select {
     width: 5vw;
 }
 
+.route-settings .time-flatpickr {
+    width: 6rem;
+}
+
+.route-tabs {
+    gap: 0.5rem;
+}
+
+.route-tab {
+    transition: background-color 0.2s ease, color 0.2s ease;
+}
+
+.route-tab.active {
+    background-color: #2660ff;
+    color: #fff;
+    border-color: #2660ff;
+}
+
+.route-tab-panels {
+    height: calc(100% - 3rem);
+}
+
+.route-tab-panel {
+    display: none;
+    height: 100%;
+}
+
+.route-tab-panel.active {
+    display: block;
+}
+
+.route-tab-panel .form-text {
+    font-size: 0.875rem;
+}
+
 .route-info {
     flex: 0 0 auto;
     width: 33.33333333%;

--- a/views/erpscreen.pug
+++ b/views/erpscreen.pug
@@ -781,12 +781,31 @@ block content
                     input.route-description.form-control(type="text" )
                 button.save-route.btn.btn-outline-primary KAYDET
             .route-settings.h-100
-                .input-group.mb-3
-                    select.route-stop-place.form-select()
-                        option(value="" selected)
-                    input.route-stop-duration.form-control(placeholder="00:00" type="text" style="display:none;" pattern="^([01]\d|2[0-3]):([0-5]\d)$")
-                    button.add-route-stop-button.btn.btn-outline-primary(type="button") EKLE
-                .route-stops.d-flex.flex-column.gap-3
+                .route-tabs.d-flex.mb-3
+                    button.route-tab.btn.btn-outline-primary.active(type="button" data-target="route-stops-tab") Hat Durakları
+                    button.route-tab.btn.btn-outline-primary(type="button" data-target="route-config-tab") Ayarlar
+                .route-tab-panels
+                    .route-tab-panel#route-stops-tab.active
+                        .input-group.mb-3
+                            select.route-stop-place.form-select()
+                                option(value="" selected)
+                            input.route-stop-duration.form-control(placeholder="00:00" type="text" style="display:none;" pattern="^([01]\d|2[0-3]):([0-5]\d)$")
+                            button.add-route-stop-button.btn.btn-outline-primary(type="button") EKLE
+                        .route-stops.d-flex.flex-column.gap-3
+                    .route-tab-panel#route-config-tab
+                        .input-group.mb-3
+                            span.input-group-text Rezervasyon Opsiyon Süresi
+                            input.route-reservation-option-time.form-control.time-flatpickr(type="text" placeholder="00:00" autocomplete="off")
+                        p.form-text.text-muted.mb-3 Boş bırakırsanız rezervasyonlar sefer saatinde düşer
+                        .input-group.mb-3
+                            span.input-group-text İade Transfer Opsiyon Süresi
+                            input.route-transfer-option-time.form-control.time-flatpickr(type="text" placeholder="00:00" autocomplete="off")
+                        .input-group.mb-3
+                            span.input-group-text Max Rezervasyon Sayısı
+                            input.route-max-reservation-count.form-control(type="number" min="0" step="1" placeholder="Sınırsız")
+                        .input-group
+                            span.input-group-text Max Tek Koltuk Sayısı
+                            input.route-max-single-seat-count.form-control(type="number" min="0" step="1" placeholder="Sınırsız")
 
     .trip
         .gtr-header


### PR DESCRIPTION
## Summary
- introduce a tabbed route settings panel with new configuration inputs for reservation/transfer options and seat limits
- add styling and client-side logic for the new controls, including time pickers, tab switching, and clearer error handling during ticket actions
- extend the route model and ticket flows to persist the new settings and enforce reservation and single-seat limits, even when moving tickets

## Testing
- npm start *(fails: missing ./utilities/goturDB module in this environment)*

------
https://chatgpt.com/codex/tasks/task_e_68d7dcd1cebc8322bf3dfd14834694fe