### PR TITLE
Add bidirectional price option

### DIFF
--- a/controllers/erpController.js
+++ b/controllers/erpController.js
@@ -1779,6 +1779,23 @@ exports.getTicketRow = async (req, res, next) => {
         order: [["order", "ASC"]],
     });
 
+    const findPriceForStops = async (fromStopId, toStopId) => {
+        if (!fromStopId || !toStopId) return null;
+
+        let priceRecord = await req.models.Price.findOne({ where: { fromStopId, toStopId } });
+        if (!priceRecord) {
+            priceRecord = await req.models.Price.findOne({
+                where: {
+                    fromStopId: toStopId,
+                    toStopId: fromStopId,
+                    isBidirectional: true,
+                },
+            });
+        }
+
+        return priceRecord;
+    };
+
     const routeStopOrder = stopId
         ? routeStops.find((rs) => String(rs.stopId) === String(stopId))?.order
         : null;
@@ -1799,7 +1816,7 @@ exports.getTicketRow = async (req, res, next) => {
         const { fromId, toId, count } = req.query;
         let price = 0;
         if (fromId && toId) {
-            const p = await req.models.Price.findOne({ where: { fromStopId: fromId, toStopId: toId } });
+            const p = await findPriceForStops(fromId, toId);
             price = p ? p : 0;
         }
 
@@ -1858,7 +1875,7 @@ exports.getTicketRow = async (req, res, next) => {
                     const key = `${fromStopId}-${toStopId}`;
 
                     if (!(key in priceCache)) {
-                        priceCache[key] = await req.models.Price.findOne({ where: { fromStopId, toStopId } });
+                        priceCache[key] = await findPriceForStops(fromStopId, toStopId);
                     }
 
                     priceForSeat = priceCache[key];
@@ -1876,7 +1893,7 @@ exports.getTicketRow = async (req, res, next) => {
     const gender = seats ? seats.map((s) => genderParam) : [];
     let price = 0;
     if (fromId && toId) {
-        const p = await req.models.Price.findOne({ where: { fromStopId: fromId, toStopId: toId } });
+        const p = await findPriceForStops(fromId, toId);
         price = p ? p : null;
     }
 
@@ -2828,7 +2845,8 @@ exports.getPricesList = async (req, res, next) => {
             toTitle: stopMap[p.toStopId] || p.toStopId,
             validFrom: obj.validFrom ? new Date(obj.validFrom).toLocaleDateString() : "",
             validUntil: obj.validUntil ? new Date(obj.validUntil).toLocaleDateString() : "",
-            hourLimit: obj.hourLimit ? obj.hourLimit : ""
+            hourLimit: obj.hourLimit ? obj.hourLimit : "",
+            isBidirectional: Boolean(obj.isBidirectional)
         };
     });
 
@@ -2847,11 +2865,22 @@ exports.postSavePrices = async (req, res, next) => {
             return Number.isFinite(num) && num > 0 ? num : null;
         };
 
+        const toBoolean = val => {
+            if (typeof val === "boolean") return val;
+            if (typeof val === "number") return val === 1;
+            if (typeof val === "string") {
+                const normalized = val.trim().toLowerCase();
+                return normalized === "true" || normalized === "1" || normalized === "on";
+            }
+            return false;
+        };
+
         for (const price of prices) {
             const {
                 id,
                 fromStopId,
                 toStopId,
+                isBidirectional,
                 price1,
                 price2,
                 price3,
@@ -2870,6 +2899,7 @@ exports.postSavePrices = async (req, res, next) => {
                 {
                     fromStopId,
                     toStopId,
+                    isBidirectional: toBoolean(isBidirectional),
                     price1: toNullIfNotPositive(price1),
                     price2: toNullIfNotPositive(price2),
                     price3: toNullIfNotPositive(price3),
@@ -2899,6 +2929,7 @@ exports.postAddPrice = async (req, res, next) => {
         const {
             fromStopId,
             toStopId,
+            isBidirectional,
             price1,
             price2,
             price3,
@@ -2918,9 +2949,20 @@ exports.postAddPrice = async (req, res, next) => {
             return Number.isFinite(num) && num > 0 ? num : null;
         };
 
+        const toBoolean = val => {
+            if (typeof val === "boolean") return val;
+            if (typeof val === "number") return val === 1;
+            if (typeof val === "string") {
+                const normalized = val.trim().toLowerCase();
+                return normalized === "true" || normalized === "1" || normalized === "on";
+            }
+            return false;
+        };
+
         await req.models.Price.create({
             fromStopId,
             toStopId,
+            isBidirectional: toBoolean(isBidirectional),
             price1: toNullIfNotPositive(price1),
             price2: toNullIfNotPositive(price2),
             price3: toNullIfNotPositive(price3),

--- a/models/priceModel.js
+++ b/models/priceModel.js
@@ -63,5 +63,10 @@ module.exports = (sequelize) => {
       type: DataTypes.INTEGER,
       allowNull: true,
     },
+    isBidirectional: {
+      type: DataTypes.BOOLEAN,
+      allowNull: false,
+      defaultValue: false,
+    },
   });
 };

--- a/public/scripts/erp.js
+++ b/public/scripts/erp.js
@@ -4959,7 +4959,13 @@ const resetPriceAddRow = () => {
         });
         $(this).html(options);
     });
-    row.find("input").val("");
+    row.find("input.price-button-input").val("");
+    row.find(".price-bidirectional").prop("checked", false);
+    row.find(".date-picker").each(function () {
+        if (this._flatpickr) {
+            this._flatpickr.clear();
+        }
+    });
     flatpickr(row.find(".date-picker").toArray(), {
         dateFormat: "Y-m-d",
         altInput: true,
@@ -5009,12 +5015,23 @@ $(".price-row, .price-add-row").off().on("click", function () {
             });
             select += '</select>';
             p.replaceWith(select);
+        } else if (index === 2) {
+            const isChecked = value === true || value === "true" || value === 1 || value === "1";
+            const checkbox = $("<input>", {
+                type: "checkbox",
+                class: "form-check-input price-bidirectional"
+            });
+            checkbox.prop("checked", isChecked);
+            p.replaceWith(checkbox);
+            $(this).addClass("d-flex justify-content-center align-items-center");
         } else {
-            let cls = "price-button-input";
+            const classes = ["price-button-input"];
             let type = "text";
-            if (index === 11) { cls += " hour-limit"; type = "number"; }
-            if (index === 12 || index === 13) cls += " date-picker";
-            p.replaceWith(`<input class="${cls}" type="${type}" value="${value ?? ''}">`);
+            if (index === 12) { classes.push("hour-limit"); type = "number"; }
+            if (index === 13 || index === 14) classes.push("date-picker");
+            const input = $("<input>", { type, value: value ?? "" });
+            input.addClass(classes.join(" "));
+            p.replaceWith(input);
         }
     });
     flatpickr(row.find(".date-picker").toArray(), {
@@ -5029,7 +5046,8 @@ $(".price-save").on("click", async function () {
     $(".price-list-nodes .price-button-inputs").each(function () {
         const row = $(this);
         const selects = row.find("select");
-        const inputs = row.find("input");
+        const priceInputs = row.find("input.price-button-input");
+        const bidirectionalInput = row.find(".price-bidirectional");
         const toNullIfNotPositive = val => {
             const num = Number(val);
             return Number.isFinite(num) && num > 0 ? num : null;
@@ -5038,18 +5056,19 @@ $(".price-save").on("click", async function () {
             id: row.data("id"),
             fromStopId: selects.eq(0).val(),
             toStopId: selects.eq(1).val(),
-            price1: toNullIfNotPositive(inputs.eq(0).val()),
-            price2: toNullIfNotPositive(inputs.eq(1).val()),
-            price3: toNullIfNotPositive(inputs.eq(2).val()),
-            webPrice: toNullIfNotPositive(inputs.eq(3).val()),
-            singleSeatPrice1: toNullIfNotPositive(inputs.eq(4).val()),
-            singleSeatPrice2: toNullIfNotPositive(inputs.eq(5).val()),
-            singleSeatPrice3: toNullIfNotPositive(inputs.eq(6).val()),
-            singleSeatWebPrice: toNullIfNotPositive(inputs.eq(7).val()),
-            seatLimit: inputs.eq(8).val(),
-            hourLimit: inputs.eq(9).val() ? Number(inputs.eq(9).val()) : null,
-            validFrom: inputs.eq(10).val() ? `${inputs.eq(10).val()}T00:00` : null,
-            validUntil: inputs.eq(11).val() ? `${inputs.eq(11).val()}T00:00` : null
+            isBidirectional: bidirectionalInput.is(":checked"),
+            price1: toNullIfNotPositive(priceInputs.eq(0).val()),
+            price2: toNullIfNotPositive(priceInputs.eq(1).val()),
+            price3: toNullIfNotPositive(priceInputs.eq(2).val()),
+            webPrice: toNullIfNotPositive(priceInputs.eq(3).val()),
+            singleSeatPrice1: toNullIfNotPositive(priceInputs.eq(4).val()),
+            singleSeatPrice2: toNullIfNotPositive(priceInputs.eq(5).val()),
+            singleSeatPrice3: toNullIfNotPositive(priceInputs.eq(6).val()),
+            singleSeatWebPrice: toNullIfNotPositive(priceInputs.eq(7).val()),
+            seatLimit: priceInputs.eq(8).val(),
+            hourLimit: priceInputs.eq(9).val() ? Number(priceInputs.eq(9).val()) : null,
+            validFrom: priceInputs.eq(10).val() ? `${priceInputs.eq(10).val()}T00:00` : null,
+            validUntil: priceInputs.eq(11).val() ? `${priceInputs.eq(11).val()}T00:00` : null
         };
         data.push(obj);
     });
@@ -5085,7 +5104,8 @@ const savePriceAdd = async closeAfterSave => {
     const row = popup.find(".price-add-row");
     if (!row.hasClass("price-button-inputs")) row.click();
     const selects = row.find("select");
-    const inputs = row.find("input");
+    const priceInputs = row.find("input.price-button-input");
+    const bidirectionalInput = row.find(".price-bidirectional");
     const toNullIfNotPositive = val => {
         const num = Number(val);
         return Number.isFinite(num) && num > 0 ? num : null;
@@ -5093,18 +5113,19 @@ const savePriceAdd = async closeAfterSave => {
     const data = {
         fromStopId: selects.eq(0).val(),
         toStopId: selects.eq(1).val(),
-        price1: toNullIfNotPositive(inputs.eq(0).val()),
-        price2: toNullIfNotPositive(inputs.eq(1).val()),
-        price3: toNullIfNotPositive(inputs.eq(2).val()),
-        webPrice: toNullIfNotPositive(inputs.eq(3).val()),
-        singleSeatPrice1: toNullIfNotPositive(inputs.eq(4).val()),
-        singleSeatPrice2: toNullIfNotPositive(inputs.eq(5).val()),
-        singleSeatPrice3: toNullIfNotPositive(inputs.eq(6).val()),
-        singleSeatWebPrice: toNullIfNotPositive(inputs.eq(7).val()),
-        seatLimit: inputs.eq(8).val(),
-        hourLimit: inputs.eq(9).val(),
-        validFrom: inputs.eq(10).val(),
-        validUntil: inputs.eq(11).val()
+        isBidirectional: bidirectionalInput.is(":checked"),
+        price1: toNullIfNotPositive(priceInputs.eq(0).val()),
+        price2: toNullIfNotPositive(priceInputs.eq(1).val()),
+        price3: toNullIfNotPositive(priceInputs.eq(2).val()),
+        webPrice: toNullIfNotPositive(priceInputs.eq(3).val()),
+        singleSeatPrice1: toNullIfNotPositive(priceInputs.eq(4).val()),
+        singleSeatPrice2: toNullIfNotPositive(priceInputs.eq(5).val()),
+        singleSeatPrice3: toNullIfNotPositive(priceInputs.eq(6).val()),
+        singleSeatWebPrice: toNullIfNotPositive(priceInputs.eq(7).val()),
+        seatLimit: priceInputs.eq(8).val(),
+        hourLimit: priceInputs.eq(9).val(),
+        validFrom: priceInputs.eq(10).val(),
+        validUntil: priceInputs.eq(11).val()
     };
 
     await $.ajax({

--- a/views/erpscreen.pug
+++ b/views/erpscreen.pug
@@ -1038,6 +1038,8 @@ block content
                         .col
                             p.text-center.m-0 Nereye
                         .col
+                            p.text-center.m-0 Çift Yön
+                        .col
                             p.text-center.m-0 Fiyat1
                         .col
                             p.text-center.m-0 Fiyat2
@@ -1079,6 +1081,8 @@ block content
                 .col
                     p.text-center.m-0 Nereye
                 .col
+                    p.text-center.m-0 Çift Yön
+                .col
                     p.text-center.m-0 Fiyat1
                 .col
                     p.text-center.m-0 Fiyat2
@@ -1107,6 +1111,8 @@ block content
                     select.price-button-select
                 .col
                     select.price-button-select
+                .col.d-flex.justify-content-center.align-items-center
+                    input.price-bidirectional.form-check-input(type="checkbox")
                 .col
                     input.price-button-input(type="text" value="")
                 .col

--- a/views/mixins/pricesList.pug
+++ b/views/mixins/pricesList.pug
@@ -7,6 +7,8 @@ each p in prices
             .col
                 p.text-center.m-0(data-value=p.toStopId) #{p.toTitle}
             .col
+                p.text-center.m-0(data-value=p.isBidirectional) #{p.isBidirectional ? "Evet" : "Hayır"}
+            .col
                 p.text-center.m-0 #{p.price1}
             .col
                 p.text-center.m-0 #{p.price2}


### PR DESCRIPTION
## Summary
- add an `isBidirectional` flag to prices so that a single record can cover both directions when desired
- update price lookups and persistence logic to respect the bidirectional setting on the server
- expose the bidirectional toggle in the ERP price management UI so operators can control it during entry and edits

## Testing
- Not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68d7dd7d0384832295985bf7664e6de0