### PR TITLE
Fix stop lookup for external return tickets report

### DIFF
--- a/controllers/erpController.js
+++ b/controllers/erpController.js
@@ -12,6 +12,7 @@ const generateWebTicketsReportByStopDetailed = require('../utilities/reports/web
 const generateWebTicketsReportByStopSummary = require('../utilities/reports/webTicketsByStopSummary');
 const { generateDailyUserAccountReport, formatCurrency: formatDailyCurrency } = require('../utilities/reports/dailyUserAccountReport');
 const generateUpcomingTicketsReport = require("../utilities/reports/upcomingTicketsReport");
+const generateExternalReturnTicketsReport = require('../utilities/reports/externalReturnTicketsReport');
 
 async function generatePNR(models, fromId, toId, stops) {
     const from = stops.find(s => s.id == fromId)?.title;
@@ -5427,6 +5428,381 @@ exports.getUpcomingTicketsReport = async (req, res, next) => {
     } catch (err) {
         console.error("getUpcomingTicketsReport error:", err);
         res.status(500).json({ message: "İleri tarihli satışlar raporu oluşturulamadı." });
+    }
+};
+
+exports.getExternalReturnTicketsReport = async (req, res, next) => {
+    try {
+        const { startDate, endDate, branchId: rawBranchId, userId: rawUserId } = req.query;
+        const safeId = value => {
+            const num = Number(value);
+            return Number.isFinite(num) ? num : null;
+        };
+        const normalizeDate = value => {
+            if (!value) return null;
+            if (value instanceof Date) {
+                return Number.isNaN(value.getTime()) ? null : value;
+            }
+            const date = new Date(value);
+            return Number.isNaN(date.getTime()) ? null : date;
+        };
+        const parseDateTime = value => {
+            if (!value) return null;
+            const normalized = String(value).replace(" ", "T");
+            const parsed = new Date(normalized);
+            return Number.isNaN(parsed.getTime()) ? null : parsed;
+        };
+        const formatDateTime = value => {
+            const date = normalizeDate(value);
+            if (!date) return "Belirtilmedi";
+            return new Intl.DateTimeFormat("tr-TR", {
+                day: "2-digit",
+                month: "2-digit",
+                year: "numeric",
+                hour: "2-digit",
+                minute: "2-digit",
+                hour12: false
+            }).format(date);
+        };
+        const branchId = safeId(rawBranchId);
+        const userId = safeId(rawUserId);
+        const start = parseDateTime(startDate);
+        const end = parseDateTime(endDate);
+
+        const [branchRecord, userRecord] = await Promise.all([
+            branchId ? req.models.Branch.findOne({ where: { id: branchId }, attributes: ["id", "title"], raw: true }) : Promise.resolve(null),
+            userId ? req.models.FirmUser.findOne({ where: { id: userId }, attributes: ["id", "name", "branchId"], raw: true }) : Promise.resolve(null)
+        ]);
+
+        let allowedUserIds = null;
+        if (branchId) {
+            const branchUsers = await req.models.FirmUser.findAll({
+                where: { branchId },
+                attributes: ["id"],
+                raw: true
+            });
+            const ids = branchUsers.map(u => safeId(u.id)).filter(id => id !== null);
+            allowedUserIds = new Set(ids);
+        }
+
+        if (userId !== null) {
+            if (allowedUserIds) {
+                if (allowedUserIds.has(userId)) {
+                    allowedUserIds = new Set([userId]);
+                } else {
+                    allowedUserIds = new Set();
+                }
+            } else {
+                allowedUserIds = new Set([userId]);
+            }
+        }
+
+        const allowedIdList = allowedUserIds ? Array.from(allowedUserIds.values()) : null;
+
+        const statuses = ["completed", "web", "gotur"];
+        const where = {
+            status: { [Op.in]: statuses }
+        };
+
+        if (start || end) {
+            where.createdAt = {};
+            if (start) where.createdAt[Op.gte] = start;
+            if (end) where.createdAt[Op.lte] = end;
+        }
+
+        if (allowedIdList) {
+            if (allowedIdList.length === 1) {
+                where.userId = allowedIdList[0];
+            } else if (allowedIdList.length > 1) {
+                where.userId = { [Op.in]: allowedIdList };
+            }
+        }
+
+        let tickets = [];
+        if (!allowedIdList || allowedIdList.length) {
+            tickets = await req.models.Ticket.findAll({
+                where,
+                attributes: ["id", "tripId", "userId", "createdAt", "fromRouteStopId", "toRouteStopId", "pnr", "payment", "gender", "price"],
+                order: [["createdAt", "ASC"]],
+                raw: true
+            });
+        }
+
+        const toKey = value => (value === undefined || value === null) ? "" : String(value);
+        const makeRouteStopKey = (routeId, stopId) => `${toKey(safeId(routeId))}|${toKey(safeId(stopId))}`;
+
+        const userIds = [...new Set(tickets.map(t => safeId(t.userId)).filter(id => id !== null))];
+        const users = userIds.length ? await req.models.FirmUser.findAll({
+            where: { id: { [Op.in]: userIds } },
+            raw: true
+        }) : [];
+
+        const branchIds = [...new Set(users.map(u => safeId(u.branchId)).filter(id => id !== null))];
+        const branches = branchIds.length ? await req.models.Branch.findAll({
+            where: { id: { [Op.in]: branchIds } },
+            raw: true
+        }) : [];
+
+        const tripIds = [...new Set(tickets.map(t => safeId(t.tripId)).filter(id => id !== null))];
+        const trips = tripIds.length ? await req.models.Trip.findAll({
+            where: { id: { [Op.in]: tripIds } },
+            raw: true
+        }) : [];
+
+        const routeIds = [...new Set(trips.map(t => safeId(t.routeId)).filter(id => id !== null))];
+        const routes = routeIds.length ? await req.models.Route.findAll({
+            where: { id: { [Op.in]: routeIds } },
+            raw: true
+        }) : [];
+
+        const routeStops = routeIds.length ? await req.models.RouteStop.findAll({
+            where: { routeId: { [Op.in]: routeIds } },
+            order: [["routeId", "ASC"], ["order", "ASC"]],
+            raw: true
+        }) : [];
+
+        const stopIdSet = new Set();
+        routeStops.forEach(rs => {
+            const stopId = safeId(rs.stopId);
+            if (stopId !== null) stopIdSet.add(stopId);
+        });
+        routes.forEach(route => {
+            const fromId = safeId(route.fromStopId);
+            const toId = safeId(route.toStopId);
+            if (fromId !== null) stopIdSet.add(fromId);
+            if (toId !== null) stopIdSet.add(toId);
+        });
+        tickets.forEach(ticket => {
+            const fromId = safeId(ticket.fromRouteStopId);
+            const toId = safeId(ticket.toRouteStopId);
+            if (fromId !== null) stopIdSet.add(fromId);
+            if (toId !== null) stopIdSet.add(toId);
+        });
+
+        const stopIds = [...stopIdSet];
+        const stops = stopIds.length ? await req.models.Stop.findAll({
+            where: { id: { [Op.in]: stopIds } },
+            raw: true
+        }) : [];
+
+        const userMap = new Map(users.map(user => [toKey(user.id), user]));
+        const branchMap = new Map(branches.map(branch => [toKey(branch.id), branch]));
+        const tripMap = new Map(trips.map(trip => [toKey(trip.id), trip]));
+        const routeMap = new Map(routes.map(route => [toKey(route.id), route]));
+        const routeStopMap = new Map(routeStops.map(rs => [toKey(rs.id), rs]));
+        const routeStopByRouteAndStop = new Map();
+        routeStops.forEach(rs => {
+            const routeKey = safeId(rs.routeId);
+            const stopKey = safeId(rs.stopId);
+            if (routeKey === null || stopKey === null) {
+                return;
+            }
+            routeStopByRouteAndStop.set(makeRouteStopKey(routeKey, stopKey), rs);
+        });
+        const stopMap = new Map(stops.map(stop => [toKey(stop.id), stop.title]));
+
+        const routeStopsByRoute = new Map();
+        routeStops.forEach(rs => {
+            const key = toKey(rs.routeId);
+            if (!routeStopsByRoute.has(key)) {
+                routeStopsByRoute.set(key, []);
+            }
+            routeStopsByRoute.get(key).push(rs);
+        });
+        routeStopsByRoute.forEach(list => {
+            list.sort((a, b) => (Number(a.order) || 0) - (Number(b.order) || 0));
+        });
+
+        const parseDurationToMs = duration => {
+            if (!duration) return 0;
+            const [rawH = 0, rawM = 0, rawS = 0] = String(duration).split(":").map(Number);
+            const hours = Number.isFinite(rawH) ? rawH : 0;
+            const minutes = Number.isFinite(rawM) ? rawM : 0;
+            const seconds = Number.isFinite(rawS) ? rawS : 0;
+            return ((hours || 0) * 3600 + (minutes || 0) * 60 + (seconds || 0)) * 1000;
+        };
+
+        const cumulativeDurationByRouteStopId = new Map();
+        routeStopsByRoute.forEach(list => {
+            let acc = 0;
+            list.forEach(rs => {
+                acc += parseDurationToMs(rs.duration);
+                cumulativeDurationByRouteStopId.set(toKey(rs.id), acc);
+            });
+        });
+
+        const combineDateAndTime = (dateStr, timeStr) => {
+            if (!dateStr) return null;
+            const [year, month, day] = String(dateStr).split("-").map(Number);
+            if (!year || !month || !day) return null;
+            const [hour = 0, minute = 0, second = 0] = String(timeStr || "00:00:00").split(":").map(Number);
+            return new Date(year, (month || 1) - 1, day || 1, hour || 0, minute || 0, second || 0);
+        };
+
+        const asciiMap = { 'ç': 'c', 'Ç': 'c', 'ğ': 'g', 'Ğ': 'g', 'ı': 'i', 'İ': 'i', 'ö': 'o', 'Ö': 'o', 'ş': 's', 'Ş': 's', 'ü': 'u', 'Ü': 'u' };
+        const toAscii = text => String(text || "").replace(/[çÇğĞıİöÖşŞüÜ]/g, chr => asciiMap[chr] || chr);
+        const isExternalReturnRoute = route => {
+            if (!route) return false;
+            const base = [route.title, route.description, route.routeCode]
+                .filter(Boolean)
+                .map(value => String(value).toLocaleLowerCase("tr-TR"))
+                .join(" ");
+            if (!base) return false;
+            const ascii = toAscii(base);
+            const hasExternal = base.includes("dış") || ascii.includes("dis");
+            const hasReturn = base.includes("dönüş") || ascii.includes("donus");
+            return hasExternal && hasReturn;
+        };
+
+        const formatRouteSummary = (fromTitle, toTitle) => {
+            const safeFrom = fromTitle || "-";
+            const safeTo = toTitle || "";
+            return safeTo ? `${safeFrom} - ${safeTo}` : safeFrom;
+        };
+
+        const totals = { amount: 0, count: 0 };
+        const branchBuckets = new Map();
+
+        tickets.forEach(ticket => {
+            const user = ticket.userId ? userMap.get(toKey(ticket.userId)) : null;
+            const trip = ticket.tripId ? tripMap.get(toKey(ticket.tripId)) : null;
+            if (!user || !trip) return;
+
+            const route = trip.routeId ? routeMap.get(toKey(trip.routeId)) : null;
+            if (!route || !isExternalReturnRoute(route)) return;
+
+            const branch = user.branchId ? branchMap.get(toKey(user.branchId)) : null;
+            const branchKey = branch ? toKey(branch.id) : "none";
+            if (!branchBuckets.has(branchKey)) {
+                branchBuckets.set(branchKey, {
+                    id: branch?.id ?? null,
+                    title: branch?.title || "Belirtilmemiş Şube",
+                    users: new Map(),
+                    totals: { amount: 0, count: 0 }
+                });
+            }
+            const branchBucket = branchBuckets.get(branchKey);
+
+            const userKey = user ? toKey(user.id) : `none-${branchKey}`;
+            if (!branchBucket.users.has(userKey)) {
+                branchBucket.users.set(userKey, {
+                    id: user?.id ?? null,
+                    name: user?.name || "Belirtilmemiş Kullanıcı",
+                    tickets: [],
+                    totals: { amount: 0, count: 0 }
+                });
+            }
+            const userBucket = branchBucket.users.get(userKey);
+
+            const baseDate = combineDateAndTime(trip.date, trip.time);
+            let departureDate = baseDate ? new Date(baseDate) : null;
+            const fromRouteStopKey = makeRouteStopKey(route?.id, ticket.fromRouteStopId);
+            const fromRouteStop = fromRouteStopKey ? routeStopByRouteAndStop.get(fromRouteStopKey) : null;
+            if (fromRouteStop && departureDate) {
+                const offset = cumulativeDurationByRouteStopId.get(toKey(fromRouteStop.id));
+                if (typeof offset === "number") {
+                    departureDate = new Date(departureDate.getTime() + offset);
+                }
+            }
+
+            const fromStopTitle = stopMap.get(toKey(ticket.fromRouteStopId))
+                || (fromRouteStop ? stopMap.get(toKey(fromRouteStop.stopId)) : "")
+                || "";
+            const toRouteStopKey = makeRouteStopKey(route?.id, ticket.toRouteStopId);
+            const toRouteStop = toRouteStopKey ? routeStopByRouteAndStop.get(toRouteStopKey) : null;
+            const toStopTitle = stopMap.get(toKey(ticket.toRouteStopId))
+                || (toRouteStop ? stopMap.get(toKey(toRouteStop.stopId)) : "")
+                || "";
+            const fallbackFrom = route.fromStopId ? stopMap.get(toKey(route.fromStopId)) : "";
+            const fallbackTo = route.toStopId ? stopMap.get(toKey(route.toStopId)) : "";
+
+            const routeSummary = formatRouteSummary(fromStopTitle || fallbackFrom, toStopTitle || fallbackTo);
+            const departureStop = fromStopTitle || fallbackFrom || "";
+
+            const normalizeGender = value => {
+                if (!value) return "";
+                const lowered = String(value).toLowerCase();
+                if (lowered === "f") return "K";
+                if (lowered === "m") return "E";
+                return value.toString().toUpperCase();
+            };
+
+            const normalizePayment = value => {
+                const lowered = String(value || "").toLowerCase();
+                if (lowered === "cash") return "Nakit";
+                if (lowered === "card") return "K.Kartı";
+                if (lowered === "point") return "Puan";
+                if (lowered === "web") return "Web";
+                return value ? value.toString().toUpperCase() : "-";
+            };
+
+            const transactionDate = normalizeDate(ticket.createdAt);
+            const price = Number(ticket.price) || 0;
+
+            userBucket.tickets.push({
+                branch: branchBucket.title,
+                user: userBucket.name,
+                transactionDate,
+                tripInfo: {
+                    route: routeSummary,
+                    departureStop,
+                    departureTime: departureDate
+                },
+                payment: normalizePayment(ticket.payment),
+                gender: normalizeGender(ticket.gender),
+                pnr: ticket.pnr || "",
+                price
+            });
+
+            userBucket.totals.amount += price;
+            userBucket.totals.count += 1;
+            branchBucket.totals.amount += price;
+            branchBucket.totals.count += 1;
+            totals.amount += price;
+            totals.count += 1;
+        });
+
+        const preparedBranches = Array.from(branchBuckets.values()).map(branch => {
+            const usersArray = Array.from(branch.users.values()).map(user => {
+                user.tickets.sort((a, b) => {
+                    const timeA = normalizeDate(a.transactionDate)?.getTime() || 0;
+                    const timeB = normalizeDate(b.transactionDate)?.getTime() || 0;
+                    return timeA - timeB;
+                });
+                return {
+                    id: user.id,
+                    name: user.name,
+                    tickets: user.tickets,
+                    totals: user.totals
+                };
+            }).sort((a, b) => a.name.localeCompare(b.name, "tr-TR"));
+
+            return {
+                id: branch.id,
+                title: branch.title,
+                users: usersArray,
+                totals: branch.totals
+            };
+        }).sort((a, b) => a.title.localeCompare(b.title, "tr-TR"));
+
+        const reportData = {
+            generatedAt: new Date(),
+            query: {
+                startDate: formatDateTime(start),
+                endDate: formatDateTime(end),
+                branch: branchRecord?.title || "Tümü",
+                user: userRecord?.name || "Tümü"
+            },
+            totals,
+            branches: preparedBranches
+        };
+
+        res.setHeader("Content-Type", "application/pdf");
+        res.setHeader("Content-Disposition", "inline; filename=\"external_return_tickets.pdf\"");
+        await generateExternalReturnTicketsReport(reportData, res);
+    } catch (err) {
+        console.error("getExternalReturnTicketsReport error:", err);
+        res.status(500).json({ message: "Dış bölge (dönüş) bilet raporu oluşturulamadı." });
     }
 };
 

--- a/public/scripts/erp.js
+++ b/public/scripts/erp.js
@@ -5956,6 +5956,41 @@ $(".report-item").on("click", async e => {
         popup.data("initialized", true);
     }
 
+    if (report === "externalReturnTickets" && !popup.data("initialized")) {
+        try {
+            const branches = await fetch("/get-branches-list?onlyData=true").then(r => r.json());
+            const branchSel = popup.find(".report-branch").empty().append('<option value="">Seçiniz</option>');
+            branches.forEach(b => branchSel.append(`<option value="${b.id}">${b.title}</option>`));
+
+            branchSel.off("change").on("change", async function () {
+                const id = $(this).val();
+                const userSel = popup.find(".report-user").empty().append('<option value="">Seçiniz</option>');
+                if (id) {
+                    try {
+                        const users = await fetch(`/get-users-by-branch?id=${id}`).then(r => r.json());
+                        users.forEach(u => userSel.append(`<option value="${u.id}">${u.name}</option>`));
+                    } catch (err) {
+                        console.error("externalReturnTickets users load error", err);
+                    }
+                }
+            });
+
+            const startInput = popup.find(".report-start")[0];
+            if (startInput) {
+                flatpickr(startInput, { enableTime: true, dateFormat: "Y-m-d H:i", time_24hr: true });
+            }
+
+            const endInput = popup.find(".report-end")[0];
+            if (endInput) {
+                flatpickr(endInput, { enableTime: true, dateFormat: "Y-m-d H:i", time_24hr: true });
+            }
+
+            popup.data("initialized", true);
+        } catch (err) {
+            console.error("externalReturnTickets init error", err);
+        }
+    }
+
     if (report === "dailyUserAccount" && !popup.data("initialized")) {
         try {
             const users = await fetch("/get-users-list?onlyData=true").then(r => r.json());

--- a/routes/erp.js
+++ b/routes/erp.js
@@ -147,5 +147,6 @@ router.get('/salesAndRefunds', auth, erpController.getSalesRefundsReport);
 router.get('/webTickets', auth, erpController.getWebTicketsReport);
 router.get('/dailyUserAccount', auth, erpController.getDailyUserAccountReport);
 router.get('/upcomingTickets', auth, erpController.getUpcomingTicketsReport);
+router.get('/externalReturnTickets', auth, erpController.getExternalReturnTicketsReport);
 
 module.exports = router;

--- a/utilities/reports/externalReturnTicketsReport.js
+++ b/utilities/reports/externalReturnTicketsReport.js
@@ -1,0 +1,329 @@
+const PDFDocument = require('pdfkit');
+const fs = require('fs');
+const path = require('path');
+
+const safeNumber = (value) => {
+  const num = Number(value);
+  return Number.isFinite(num) ? num : 0;
+};
+
+const formatCurrency = (value) => {
+  const amount = safeNumber(value);
+  return `${amount.toLocaleString('tr-TR', {
+    minimumFractionDigits: 2,
+    maximumFractionDigits: 2,
+  })} TL`;
+};
+
+const formatCount = (value) => {
+  const num = safeNumber(value);
+  return String(Math.round(num));
+};
+
+const normalizeDate = (value) => {
+  if (!value) return null;
+  if (value instanceof Date) {
+    return Number.isNaN(value.getTime()) ? null : value;
+  }
+  const parsed = new Date(value);
+  return Number.isNaN(parsed.getTime()) ? null : parsed;
+};
+
+const dateTimeFormatter = new Intl.DateTimeFormat('tr-TR', {
+  day: '2-digit',
+  month: '2-digit',
+  year: 'numeric',
+  hour: '2-digit',
+  minute: '2-digit',
+  hour12: false,
+});
+
+const formatDateTime = (value) => {
+  const date = normalizeDate(value);
+  return date ? dateTimeFormatter.format(date) : '';
+};
+
+function generateExternalReturnTicketsReport(data, output) {
+  const {
+    generatedAt,
+    query = {},
+    totals = {},
+    branches = [],
+  } = data || {};
+
+  const doc = new PDFDocument({ size: 'A4', margin: 40 });
+  const stream = typeof output === 'string'
+    ? fs.createWriteStream(output, { flags: 'w' })
+    : output;
+
+  doc.pipe(stream);
+
+  const regularFontPath = path.join(__dirname, 'fonts', 'DejaVuSans.ttf');
+  const boldFontPath = path.join(__dirname, 'fonts', 'DejaVuSans-Bold.ttf');
+
+  try {
+    doc.registerFont('Regular', regularFontPath);
+    doc.registerFont('Bold', boldFontPath);
+    doc.font('Regular');
+  } catch (err) {
+    console.warn('Font yüklenemedi, varsayılan font kullanılacak:', err.message);
+  }
+
+  const xStart = doc.page.margins.left;
+  const usableWidth = doc.page.width - doc.page.margins.left - doc.page.margins.right;
+  const pageBottom = doc.page.height - doc.page.margins.bottom;
+
+  const ensureSpace = (height) => {
+    if (doc.y + height > pageBottom) {
+      doc.addPage();
+      doc.font('Regular').fontSize(9);
+    }
+  };
+
+  const drawSummaryRow = (items) => {
+    if (!items.length) return;
+    const colWidth = usableWidth / items.length;
+    const rowY = doc.y;
+
+    items.forEach((item, index) => {
+      const x = xStart + index * colWidth;
+      const label = item.label?.endsWith(':') ? item.label : `${item.label}: `;
+
+      doc.font('Bold').text(label, x, rowY, {
+        width: colWidth,
+        continued: true,
+      });
+
+      doc.font('Regular').text(item.value ?? '', {
+        width: colWidth,
+      });
+    });
+
+    doc.moveDown(0.8);
+  };
+
+  const drawSummarySections = () => {
+    const startText = query.startDate || 'Belirtilmedi';
+    const endText = query.endDate || 'Belirtilmedi';
+    const branchText = query.branch || 'Tümü';
+    const userText = query.user || 'Tümü';
+    const totalCount = formatCount(totals.count || 0);
+    const totalAmount = formatCurrency(totals.amount || 0);
+
+    drawSummaryRow([
+      { label: 'Başlangıç', value: startText },
+      { label: 'Bitiş', value: endText },
+      { label: 'Rapor Tarihi', value: formatDateTime(generatedAt || new Date()) },
+    ]);
+
+    drawSummaryRow([
+      { label: 'Şube', value: branchText },
+      { label: 'Kullanıcı', value: userText },
+      { label: 'Toplam Bilet', value: totalCount },
+    ]);
+
+    drawSummaryRow([
+      { label: 'Toplam Tutar', value: totalAmount },
+    ]);
+  };
+
+  const columns = [
+    { key: 'branch', label: 'Şube', width: 46, align: 'left' },
+    { key: 'user', label: 'Kullanıcı', width: 62, align: 'left' },
+    { key: 'transactionDate', label: 'İşlem Tarihi', width: 68, align: 'center' },
+    { key: 'tripInfo', label: 'Sefer Bilgisi', width: 162, align: 'left' },
+    { key: 'payment', label: 'Tahsilat', width: 45, align: 'center' },
+    { key: 'gender', label: 'C', width: 20, align: 'center' },
+    { key: 'pnr', label: 'PNR', width: 60, align: 'center' },
+    { key: 'price', label: 'Ücret', width: 50, align: 'right' },
+  ];
+
+  const formatTripInfo = (info) => {
+    if (!info) return '';
+    const parts = [];
+    if (info.route) {
+      parts.push(info.route);
+    }
+    const departureTime = formatDateTime(info.departureTime);
+    const departurePieces = [];
+    if (info.departureStop) departurePieces.push(info.departureStop);
+    if (departureTime) departurePieces.push(departureTime);
+    if (departurePieces.length) {
+      parts.push(`Kalkış: ${departurePieces.join(' ')}`);
+    }
+    return parts.join('\n');
+  };
+
+  const formatColumnValue = (ticket, key) => {
+    switch (key) {
+      case 'transactionDate':
+        return formatDateTime(ticket.transactionDate);
+      case 'tripInfo':
+        return formatTripInfo(ticket.tripInfo);
+      case 'payment':
+        return ticket.payment || '';
+      case 'gender':
+        return ticket.gender || '';
+      case 'price':
+        return formatCurrency(ticket.price);
+      case 'branch':
+      case 'user':
+      case 'pnr':
+      default:
+        return ticket[key] ?? '';
+    }
+  };
+
+  const calculateRowHeight = (ticket) => {
+    let height = 0;
+    columns.forEach((col) => {
+      const text = formatColumnValue(ticket, col.key);
+      const textHeight = doc.heightOfString(String(text), {
+        width: col.width,
+      });
+      height = Math.max(height, textHeight + 4);
+    });
+    return height;
+  };
+
+  const drawTableHeader = () => {
+    ensureSpace(20);
+    const headerY = doc.y;
+    let x = xStart;
+
+    doc.font('Bold').fontSize(8);
+    columns.forEach((col) => {
+      doc.rect(x, headerY - 2, col.width, 16).stroke();
+      doc.text(col.label, x, headerY, {
+        width: col.width,
+        align: col.align || 'left',
+      });
+      x += col.width;
+    });
+
+    doc.moveDown(0.4);
+    doc.font('Regular').fontSize(8);
+  };
+
+  const drawRow = (ticket, rowHeight) => {
+    const rowY = doc.y;
+    let rowBottom = rowY;
+    let x = xStart;
+
+    columns.forEach((col) => {
+      const value = formatColumnValue(ticket, col.key);
+      doc.text(String(value), x, rowY, {
+        width: col.width,
+        align: col.align || 'left',
+      });
+      rowBottom = Math.max(rowBottom, doc.y);
+      doc.x = xStart;
+      doc.y = rowY;
+      x += col.width;
+    });
+
+    doc.y = Math.max(rowBottom + 2, rowY + rowHeight);
+  };
+
+  const printUserHeader = (name, isContinuation = false) => {
+    ensureSpace(18);
+    const titleText = isContinuation ? `${name} (devam)` : name;
+    doc.font('Bold').fontSize(10).text(titleText, xStart, doc.y);
+    doc.moveDown(0.3);
+    drawTableHeader();
+  };
+
+  const title = 'Dış Bölge (Dönüş) Biletleri Raporu'.toLocaleUpperCase('tr-TR');
+  doc.font('Bold').fontSize(14).text(title, xStart, doc.y, {
+    width: usableWidth,
+    align: 'center',
+  });
+  doc.moveDown(0.8);
+  doc.font('Regular').fontSize(9);
+
+  drawSummarySections();
+  doc.moveDown(0.5);
+
+  if (!branches.length) {
+    ensureSpace(20);
+    doc.font('Bold').fontSize(10).text('Listelenecek bilet bulunamadı.', xStart, doc.y);
+    doc.end();
+    return new Promise((resolve, reject) => {
+      stream.on('finish', resolve);
+      stream.on('error', reject);
+    });
+  }
+
+  branches.forEach((branch, branchIndex) => {
+    if (branchIndex > 0) {
+      doc.moveDown(0.5);
+    }
+
+    ensureSpace(24);
+    const branchTitle = branch.title || 'Belirtilmemiş Şube';
+    doc.font('Bold').fontSize(12).text(branchTitle, xStart, doc.y);
+    doc.moveDown(0.2);
+    doc.font('Regular').fontSize(9).text(
+      `Bilet: ${formatCount(branch.totals?.count)} | Tutar: ${formatCurrency(branch.totals?.amount)}`,
+      xStart,
+      doc.y,
+    );
+    doc.moveDown(0.6);
+
+    const users = Array.isArray(branch.users) ? branch.users : [];
+    if (!users.length) {
+      ensureSpace(14);
+      doc.font('Regular').fontSize(8).text('Kayıt bulunamadı.', xStart, doc.y);
+      doc.moveDown(0.6);
+    }
+
+    users.forEach((user) => {
+      const userName = user.name || 'Belirtilmemiş Kullanıcı';
+      printUserHeader(userName);
+
+      const ticketsList = Array.isArray(user.tickets) ? user.tickets : [];
+
+      if (!ticketsList.length) {
+        ensureSpace(14);
+        doc.font('Regular').fontSize(8).text('Kayıt bulunamadı.', xStart, doc.y);
+        doc.moveDown(0.6);
+      } else {
+        ticketsList.forEach((ticket) => {
+          const rowHeight = calculateRowHeight(ticket);
+          if (doc.y + rowHeight > pageBottom) {
+            doc.addPage();
+            printUserHeader(userName, true);
+          }
+          drawRow(ticket, rowHeight);
+        });
+      }
+
+      ensureSpace(14);
+      doc.font('Bold').fontSize(8).text(
+        `Kullanıcı Toplamı: ${formatCount(user.totals?.count)} bilet | ${formatCurrency(user.totals?.amount)}`,
+        xStart,
+        doc.y,
+      );
+      doc.moveDown(1);
+      doc.font('Regular').fontSize(9);
+    });
+
+    ensureSpace(16);
+    doc.font('Bold').fontSize(9).text(
+      `Şube Toplamı: ${formatCount(branch.totals?.count)} bilet | ${formatCurrency(branch.totals?.amount)}`,
+      xStart,
+      doc.y,
+    );
+    doc.moveDown(1);
+    doc.font('Regular').fontSize(9);
+  });
+
+  doc.end();
+
+  return new Promise((resolve, reject) => {
+    stream.on('finish', resolve);
+    stream.on('error', reject);
+  });
+}
+
+module.exports = generateExternalReturnTicketsReport;

--- a/views/erpscreen.pug
+++ b/views/erpscreen.pug
@@ -21,6 +21,7 @@ block content
                 li.list-group-item.report-item(data-report="webTickets") Web Biletleri
                 li.list-group-item.report-item(data-report="dailyUserAccount") Günlük Kullanıcı Hesabı
                 li.list-group-item.report-item(data-report="upcomingTickets") İleri Tarihli Satışlar
+                li.list-group-item.report-item(data-report="externalReturnTickets") Dış Bölge (Dönüş) Biletleri
 
     .salesAndRefunds-report-popup.report-popup
         .gtr-header
@@ -121,6 +122,29 @@ block content
             .input-group
                 span.input-group-text Bitiş
                 input.form-control.report-end(type="text")
+            .input-group
+                span.input-group-text Kullanıcı
+                select.form-select.report-user
+                    option(value="") Seçiniz
+            .d-flex.gap-3.justify-content-end
+                button.btn.btn-outline-primary.report-create-button OLUŞTUR
+
+    .externalReturnTickets-report-popup.report-popup
+        .gtr-header
+            span DIŞ BÖLGE (DÖNÜŞ) BİLETLERİ
+        .report-close
+            i.fa-solid.fa-x
+        .d-flex.flex-column.gap-3.p-3
+            .input-group
+                span.input-group-text Başlangıç
+                input.form-control.report-start(type="text")
+            .input-group
+                span.input-group-text Bitiş
+                input.form-control.report-end(type="text")
+            .input-group
+                span.input-group-text Şube
+                select.form-select.report-branch
+                    option(value="") Seçiniz
             .input-group
                 span.input-group-text Kullanıcı
                 select.form-select.report-user


### PR DESCRIPTION
## Summary
- map ticket stop identifiers to their route stops using the associated route when preparing the external return tickets report
- derive stop titles directly from stop records so trip summaries show the correct departure and arrival stops

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68dab92475808322a0c0a62cd7973a3e