### PR TITLE
Add user dropdown with profile and password management

### DIFF
--- a/public/scripts/erp.js
+++ b/public/scripts/erp.js
@@ -658,6 +658,206 @@ initPhoneInput(".user-phone");
 initPhoneInput(".staff-phone");
 initPhoneInput(".search-phone");
 initPhoneInput(".member-search-phone");
+initPhoneInput(".profile-phone-input");
+
+const bootstrapLib = typeof bootstrap !== "undefined" ? bootstrap : null;
+
+function getNavbarUserData() {
+    const toggle = document.querySelector(".navbar-user-toggle");
+    if (!toggle) {
+        return { name: "", username: "", phone: "" };
+    }
+
+    return {
+        name: toggle.dataset.userName || "",
+        username: toggle.dataset.userUsername || "",
+        phone: toggle.dataset.userPhone || "",
+    };
+}
+
+function setNavbarUserData(data = {}) {
+    const toggle = document.querySelector(".navbar-user-toggle");
+    if (!toggle) {
+        return;
+    }
+
+    if (typeof data.name === "string") {
+        toggle.dataset.userName = data.name;
+    }
+    if (typeof data.username === "string") {
+        toggle.dataset.userUsername = data.username;
+    }
+    if (typeof data.phone === "string") {
+        toggle.dataset.userPhone = data.phone;
+    }
+}
+
+function hideInlineError($element) {
+    if ($element && $element.length) {
+        $element.text("").addClass("d-none");
+    }
+}
+
+function showInlineError($element, message) {
+    if ($element && $element.length) {
+        $element.text(message || "Bilinmeyen hata").removeClass("d-none");
+        return;
+    }
+    showError(message);
+}
+
+const userProfileModalEl = document.getElementById("userProfileModal");
+const changePasswordModalEl = document.getElementById("changePasswordModal");
+const userProfileModal = userProfileModalEl && bootstrapLib ? new bootstrapLib.Modal(userProfileModalEl) : null;
+const changePasswordModal = changePasswordModalEl && bootstrapLib ? new bootstrapLib.Modal(changePasswordModalEl) : null;
+
+function populateProfileForm() {
+    const data = getNavbarUserData();
+    $("#profileNameInput").val(data.name || "");
+    $("#profileUsernameInput").val(data.username || "");
+    $("#profilePhoneInput").val(data.phone || "");
+}
+
+if (userProfileModalEl) {
+    populateProfileForm();
+    userProfileModalEl.addEventListener("hidden.bs.modal", () => {
+        populateProfileForm();
+        hideInlineError($("#userProfileError"));
+    });
+}
+
+if (changePasswordModalEl) {
+    changePasswordModalEl.addEventListener("hidden.bs.modal", () => {
+        const form = document.getElementById("changePasswordForm");
+        if (form) {
+            form.reset();
+        }
+        hideInlineError($("#changePasswordError"));
+    });
+}
+
+$(document).on("click", ".user-menu-profile", e => {
+    e.preventDefault();
+    hideInlineError($("#userProfileError"));
+    populateProfileForm();
+    if (userProfileModal) {
+        userProfileModal.show();
+    }
+});
+
+$(document).on("click", ".user-menu-password", e => {
+    e.preventDefault();
+    hideInlineError($("#changePasswordError"));
+    const form = document.getElementById("changePasswordForm");
+    if (form) {
+        form.reset();
+    }
+    if (changePasswordModal) {
+        changePasswordModal.show();
+    }
+});
+
+$("#userProfileForm").on("submit", async e => {
+    e.preventDefault();
+    const $error = $("#userProfileError");
+    hideInlineError($error);
+
+    const name = $("#profileNameInput").val().trim();
+    const username = $("#profileUsernameInput").val().trim();
+    const phoneNumber = $("#profilePhoneInput").val().trim();
+
+    if (!name) {
+        showInlineError($error, "Ad soyad boş bırakılamaz.");
+        return;
+    }
+
+    if (!username) {
+        showInlineError($error, "Kullanıcı adı boş bırakılamaz.");
+        return;
+    }
+
+    try {
+        showLoading();
+        const response = await $.ajax({
+            url: "/post-update-profile",
+            type: "POST",
+            data: { name, username, phoneNumber },
+        });
+        hideLoading();
+
+        const redirectUrl = response && response.redirect ? response.redirect : "/login";
+        const updatedData = {
+            name,
+            username,
+            phone: phoneNumber,
+        };
+        setNavbarUserData(updatedData);
+        window.location.href = redirectUrl;
+    } catch (err) {
+        hideLoading();
+        const message =
+            err?.responseJSON?.message ||
+            err?.responseJSON?.error ||
+            err?.responseText ||
+            err?.statusText ||
+            err?.message ||
+            "Bilinmeyen hata";
+        showInlineError($error, message);
+    }
+});
+
+$("#changePasswordForm").on("submit", async e => {
+    e.preventDefault();
+    const $error = $("#changePasswordError");
+    hideInlineError($error);
+
+    const currentPassword = $("#currentPasswordInput").val();
+    const newPassword = $("#newPasswordInput").val();
+    const confirmPassword = $("#confirmPasswordInput").val();
+
+    if (!currentPassword) {
+        showInlineError($error, "Eski şifreyi giriniz.");
+        return;
+    }
+
+    if (!newPassword) {
+        showInlineError($error, "Yeni şifreyi giriniz.");
+        return;
+    }
+
+    if (newPassword.length < 6) {
+        showInlineError($error, "Yeni şifre en az 6 karakter olmalıdır.");
+        return;
+    }
+
+    if (newPassword !== confirmPassword) {
+        showInlineError($error, "Yeni şifreler eşleşmiyor.");
+        return;
+    }
+
+    try {
+        showLoading();
+        const response = await $.ajax({
+            url: "/post-change-password",
+            type: "POST",
+            data: { currentPassword, newPassword, confirmPassword },
+        });
+        hideLoading();
+
+        const redirectUrl = response && response.redirect ? response.redirect : "/login";
+        window.location.href = redirectUrl;
+    } catch (err) {
+        hideLoading();
+        const message =
+            err?.responseJSON?.message ||
+            err?.responseJSON?.error ||
+            err?.responseText ||
+            err?.statusText ||
+            err?.message ||
+            "Bilinmeyen hata";
+        showInlineError($error, message);
+    }
+});
 initPhoneInput(".customer-search-phone");
 initPhoneInput(".trip-cargo-sender-phone");
 

--- a/routes/erp.js
+++ b/routes/erp.js
@@ -15,6 +15,8 @@ router.get('/test', erpController.test);
 router.get('/login', erpController.getErpLogin);
 router.post('/login', erpController.postErpLogin);
 router.post('/logout', auth, erpController.postErpLogout);
+router.post('/post-update-profile', auth, erpController.postUpdateProfile);
+router.post('/post-change-password', auth, erpController.postChangePassword);
 
 router.get('/permissions', auth, erpController.getPermissions);
 

--- a/views/erplayout.pug
+++ b/views/erplayout.pug
@@ -112,17 +112,70 @@ html
                 a.nav-link.reports-nav(href="#") Raporlar
           if firmUser
             - const firmUserName = firmUser && firmUser.name ? firmUser.name : ''
-            div.d-flex.align-items-center.ms-auto.gap-3
-              a.navbar-brand.d-flex.align-items-center.gap-2.mb-0(href="#")
-                //- img.d-inline-block.align-text-top(src="/images/uludag.png" alt="Logo" width="100" height="25")
-                span.text-nowrap #{firmUserName ? firmUserName : (firmUserName || 'GİRİŞ YAPILDI')}
-              form(action="/logout" method="post" class="m-0")
-                button.btn.btn-outline-danger.btn-sm.d-flex.align-items-center.gap-2(type="submit")
-                  i.fa-solid.fa-right-from-bracket
-                  span Çıkış Yap
+            - const firmUserUsername = firmUser && firmUser.username ? firmUser.username : ''
+            - const firmUserPhone = firmUser && firmUser.phoneNumber ? firmUser.phoneNumber : ''
+            - const firmUserDisplayName = firmUserName || 'GİRİŞ YAPILDI'
+            div.ms-auto.d-flex.align-items-center
+              .dropdown
+                button#navbarUserDropdown.btn.btn-outline-secondary.d-flex.align-items-center.gap-2.navbar-user-toggle(type="button" data-bs-toggle="dropdown" aria-expanded="false" data-user-name=firmUserName data-user-username=firmUserUsername data-user-phone=firmUserPhone)
+                  i.fa-solid.fa-user
+                  span.text-nowrap #{firmUserDisplayName}
+                ul.dropdown-menu.dropdown-menu-end(aria-labelledby="navbarUserDropdown")
+                  li
+                    button.user-menu-profile.dropdown-item(type="button") Bilgilerim
+                  li
+                    button.user-menu-password.dropdown-item(type="button") Şifremi Değiştir
+                  li
+                    form(action="/logout" method="post" class="m-0")
+                      button.dropdown-item.d-flex.align-items-center.gap-2.text-danger(type="submit")
+                        i.fa-solid.fa-right-from-bracket
+                        span Çıkış Yap
     div(style="padding:1rem 1rem 0rem 1rem!important;")
       block content
 
+    if firmUser
+      #userProfileModal.modal.fade(tabindex="-1" aria-labelledby="userProfileModalLabel" aria-hidden="true" data-bs-backdrop="static" data-bs-keyboard="false")
+        .modal-dialog
+          .modal-content
+            .modal-header
+              h1#userProfileModalLabel.modal-title.fs-5 Bilgilerim
+              button.btn-close(type="button" data-bs-dismiss="modal" aria-label="Kapat")
+            form#userProfileForm
+              .modal-body
+                .alert.alert-danger.d-none#userProfileError
+                .mb-3
+                  label.form-label(for="profileNameInput") Ad Soyad
+                  input#profileNameInput.form-control.profile-name-input(type="text" name="name" autocomplete="name" required)
+                .mb-3
+                  label.form-label(for="profileUsernameInput") Kullanıcı Adı
+                  input#profileUsernameInput.form-control.profile-username-input(type="text" name="username" autocomplete="username" required)
+                .mb-3
+                  label.form-label(for="profilePhoneInput") Telefon
+                  input#profilePhoneInput.form-control.profile-phone-input(type="text" name="phoneNumber" autocomplete="tel")
+              .modal-footer
+                button.btn.btn-secondary(type="button" data-bs-dismiss="modal") Vazgeç
+                button.btn.btn-primary(type="submit") Güncelle
+      #changePasswordModal.modal.fade(tabindex="-1" aria-labelledby="changePasswordModalLabel" aria-hidden="true" data-bs-backdrop="static" data-bs-keyboard="false")
+        .modal-dialog
+          .modal-content
+            .modal-header
+              h1#changePasswordModalLabel.modal-title.fs-5 Şifremi Değiştir
+              button.btn-close(type="button" data-bs-dismiss="modal" aria-label="Kapat")
+            form#changePasswordForm
+              .modal-body
+                .alert.alert-danger.d-none#changePasswordError
+                .mb-3
+                  label.form-label(for="currentPasswordInput") Eski Şifre
+                  input#currentPasswordInput.form-control(type="password" name="currentPassword" autocomplete="current-password" required)
+                .mb-3
+                  label.form-label(for="newPasswordInput") Yeni Şifre
+                  input#newPasswordInput.form-control(type="password" name="newPassword" autocomplete="new-password" required)
+                .mb-3
+                  label.form-label(for="confirmPasswordInput") Yeni Şifre (Tekrar)
+                  input#confirmPasswordInput.form-control(type="password" name="confirmPassword" autocomplete="new-password" required)
+              .modal-footer
+                button.btn.btn-secondary(type="button" data-bs-dismiss="modal") Vazgeç
+                button.btn.btn-primary(type="submit") Güncelle
     script(src="https://cdn.jsdelivr.net/npm/popper.js@1.12.9/dist/umd/popper.min.js")
     script(src="https://cdnjs.cloudflare.com/ajax/libs/bootstrap/5.3.3/js/bootstrap.bundle.min.js")
     script(src="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.7.2/js/all.min.js")


### PR DESCRIPTION
## Summary
- add a user icon dropdown to the ERP navbar with links for profile details, password changes, and logout
- implement profile and password modals with client-side validation and AJAX submissions that trigger logout after successful updates
- add backend routes to update firm user details and passwords, validating input and ending the user session after changes

## Testing
- Not run (not provided)

------
https://chatgpt.com/codex/tasks/task_e_68dae9097b24832297d4b85fcd6106e7