### PR TITLE
Fix arrival stop display in external return tickets report

### DIFF
--- a/controllers/erpController.js
+++ b/controllers/erpController.js
@@ -5567,13 +5567,22 @@ exports.getExternalReturnTicketsReport = async (req, res, next) => {
             const departureDate = getRouteStopDeparture(trip, fromRouteStop);
             const fromStopTitle = stopMap.get(toKey(fromRouteStop.stopId)) || "-";
 
-            let toStopTitle = "";
+            let toStopTitle = "-";
             const toRouteStopId = toKey(ticket.toRouteStopId);
             if (toRouteStopId) {
                 const toRouteStop = routeStopMap.get(toRouteStopId);
-                console.log("GİDİŞ:", toRouteStop)
                 if (toRouteStop?.stopId !== undefined && toRouteStop?.stopId !== null) {
-                    toStopTitle = stopMap.get(toKey(toRouteStop.stopId)) || "";
+                    const mappedStopTitle = stopMap.get(toKey(toRouteStop.stopId));
+                    if (mappedStopTitle) {
+                        toStopTitle = mappedStopTitle;
+                    }
+                }
+
+                if (toStopTitle === "-" && toRouteStop) {
+                    const fallbackTitle = toRouteStop.title || toRouteStop.name || toRouteStop.description;
+                    if (fallbackTitle) {
+                        toStopTitle = String(fallbackTitle);
+                    }
                 }
             }
 


### PR DESCRIPTION
## Summary
- ensure arrival stops are populated in the external return tickets report by falling back to stop titles or route stop metadata
- remove leftover debugging output and use a default placeholder when no arrival stop can be resolved

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68daf0e78edc832285d7e6d5b1e2bb2d