### PR TITLE
Handle seat popup toggling when clicking selected seats

### DIFF
--- a/public/scripts/erp.js
+++ b/public/scripts/erp.js
@@ -1233,10 +1233,10 @@ async function loadTrip(date, time, tripId) {
             if ($seat.data("only-gender") == "m") $(".ticket-op.f").css("display", "none");
             else if ($seat.data("only-gender") == "f") $(".ticket-op.m").css("display", "none");
 
-            const isSameSeat = currentSeat && currentSeat.is($seat) && $popup.is(":visible");
+            const isSelectedSeat = $popup.is(":visible") && ((!isTaken && selectedSeats.includes(seatNumber)) || (isTaken && selectedTakenSeats.includes(seatNumber)));
             let shouldHidePopup = false;
 
-            if (isSameSeat) {
+            if (isSelectedSeat) {
                 if (isTaken) {
                     shouldHidePopup = true;
                 } else {
@@ -1251,7 +1251,7 @@ async function loadTrip(date, time, tripId) {
             if (shouldHidePopup) {
                 $popup.hide();
                 currentSeat = null;
-            } else if (!isSameSeat) {
+            } else if (!isSelectedSeat) {
                 currentSeat = $seat;
 
                 // Popup pozisyonu


### PR DESCRIPTION
## Summary
- update seat click handler to detect any already-selected seat when determining popup behavior
- ensure remaining seat count logic runs when clicking any selected seat instead of only the current popup seat

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68dbd55d18c88322afed31221061aed6