### PR TITLE
Add tenant-specific logo selection on ERP login page

### DIFF
--- a/views/erplogin.pug
+++ b/views/erplogin.pug
@@ -2,7 +2,7 @@ extends erplayout
 
 block content
     .d-flex.flex-column.justify-content-center.align-items-center.gap-2.mt-3.h-100
-        img(src="/images/gotur_yzhn_logo.png" style="")
+        img(src=`/images/${firmLogo || 'gotur_yzhn_logo.png'}` alt="Firma Logosu" style="")
         form(action="/login" method="POST" class="d-flex align-items-center justify-content-center w-100 h-100" style="flex-direction:column; gap:10px;")
             .d-flex.flex-column
                 label.form-label Kullanıcı Adı


### PR DESCRIPTION
## Summary
- look up a tenant-specific logo for the ERP login page using the subdomain or firm display name and fall back to the default logo when not found
- render the login view with the resolved logo so firm-specific branding appears when available

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68defe9eaf3883229bbc1d9c89c6867f