### PR TITLE
Limit ticker announcements to last 24 hours

### DIFF
--- a/controllers/erpController.js
+++ b/controllers/erpController.js
@@ -4827,7 +4827,20 @@ exports.getAnnouncements = async (req, res, next) => {
         });
         const seenIds = seenRows.map(r => r.announcementId);
 
-        const ticker = announcements.filter(a => a.showTicker);
+        const twentyFourHoursAgo = new Date(Date.now() - 24 * 60 * 60 * 1000);
+
+        const ticker = announcements.filter(a => {
+            if (!a.showTicker) {
+                return false;
+            }
+
+            const createdAt = a.createdAt instanceof Date ? a.createdAt : new Date(a.createdAt);
+            if (!(createdAt instanceof Date) || Number.isNaN(createdAt.getTime())) {
+                return false;
+            }
+
+            return createdAt >= twentyFourHoursAgo;
+        });
         const popup = announcements.filter(a => a.showPopup && !seenIds.includes(a.id));
 
         res.json({ ticker, popup });


### PR DESCRIPTION
## Summary
- filter ticker announcements to only include entries created within the last 24 hours
- guard against invalid timestamps when applying the ticker filter

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68e189ccac108322a3993cb69912a5bf