### PR TITLE
Handle tenant fallback when subdomain is missing

### DIFF
--- a/bin/reservationCleanupJob.js
+++ b/bin/reservationCleanupJob.js
@@ -1,7 +1,6 @@
 const { Op } = require('sequelize');
 const { getTenantConnection } = require('../utilities/database');
-
-const DEFAULT_TENANT = process.env.TENANT_KEY;
+const { DEFAULT_TENANT_KEY } = require('../utilities/tenantConfig');
 
 // Try to use node-cron; fall back to setInterval if unavailable
 let cron;
@@ -69,7 +68,7 @@ async function cancelExpiredReservations() {
 
   let tenant;
   try {
-    tenant = await getTenantConnection(DEFAULT_TENANT);
+    tenant = await getTenantConnection(DEFAULT_TENANT_KEY);
   } catch (err) {
     console.error('Tenant connection error for reservation cleanup job:', err);
     return;

--- a/middlewares/tenantMiddleware.js
+++ b/middlewares/tenantMiddleware.js
@@ -1,10 +1,11 @@
 const { getTenantConnection } = require("../utilities/database");
 const { initGoturModels } = require("../utilities/goturDB");
+const { resolveTenantKey } = require("../utilities/tenantConfig");
 
 module.exports = async (req, res, next) => {
     try {
-        const subdomain = req.hostname.split(".")[0];
-        // const subdomain = "derseturizm"
+        const subdomain = resolveTenantKey(req.hostname);
+
         if (!subdomain) {
             return res.status(400).json({ error: "Subdomain bulunamadı" });
         }

--- a/utilities/tenantConfig.js
+++ b/utilities/tenantConfig.js
@@ -1,0 +1,38 @@
+const DEFAULT_TENANT_KEY = process.env.TENANT_KEY || "derseturizm";
+
+const LOCALHOST_TOKENS = new Set([
+  "",
+  "localhost",
+  "127",
+  "127.0.0.1",
+  "0",
+  "0.0.0.0",
+  "::1",
+]);
+
+const IPV4_PATTERN = /^\d+(?:\.\d+){3}$/;
+
+function resolveTenantKey(hostname) {
+  if (!hostname) {
+    return DEFAULT_TENANT_KEY || null;
+  }
+
+  const normalizedHost = String(hostname).toLowerCase();
+
+  if (LOCALHOST_TOKENS.has(normalizedHost) || IPV4_PATTERN.test(normalizedHost)) {
+    return DEFAULT_TENANT_KEY || null;
+  }
+
+  const [firstLabel] = normalizedHost.split(".");
+
+  if (!firstLabel || LOCALHOST_TOKENS.has(firstLabel)) {
+    return DEFAULT_TENANT_KEY || null;
+  }
+
+  return firstLabel;
+}
+
+module.exports = {
+  DEFAULT_TENANT_KEY,
+  resolveTenantKey,
+};


### PR DESCRIPTION
## Summary
- add a tenant configuration helper that resolves a default tenant when no subdomain is provided
- update the tenant middleware to use the resolver so localhost/IP hosts fall back to the configured schema
- reuse the shared default tenant value inside the reservation cleanup job

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68e18a20b4f08322908ef22691681712