### PR TITLE
Enable editing customer info from popup

### DIFF
--- a/controllers/erpController.js
+++ b/controllers/erpController.js
@@ -4296,6 +4296,128 @@ exports.postAddMember = async (req, res, next) => {
     }
 }
 
+exports.postUpdateCustomer = async (req, res, next) => {
+    try {
+        const {
+            id,
+            idNumber,
+            name,
+            surname,
+            phone,
+            gender,
+            customerType,
+            customerCategory,
+            pointOrPercent,
+            pointAmount,
+            percent
+        } = req.body;
+
+        const customerId = Number(id);
+        if (!customerId) {
+            return res.status(400).json({ success: false, message: "Geçersiz müşteri bilgisi" });
+        }
+
+        const customer = await req.models.Customer.findByPk(customerId);
+        if (!customer) {
+            return res.status(404).json({ success: false, message: "Müşteri bulunamadı" });
+        }
+
+        if (idNumber !== undefined) {
+            const parsedIdNumber = Number(idNumber);
+            if (!Number.isNaN(parsedIdNumber) && parsedIdNumber > 0) {
+                customer.idNumber = parsedIdNumber;
+            }
+        }
+
+        const upper = (value) => {
+            if (typeof value !== "string") {
+                return null;
+            }
+            const trimmed = value.trim();
+            if (!trimmed) {
+                return null;
+            }
+            try {
+                return trimmed.toLocaleUpperCase("tr-TR");
+            } catch (err) {
+                return trimmed.toUpperCase();
+            }
+        };
+
+        const trimmed = (value) => (typeof value === "string" ? value.trim() : null);
+
+        const upperName = upper(name);
+        if (upperName) {
+            customer.name = upperName;
+        }
+
+        const upperSurname = upper(surname);
+        if (upperSurname) {
+            customer.surname = upperSurname;
+        }
+
+        const trimmedPhone = trimmed(phone);
+        if (trimmedPhone) {
+            customer.phoneNumber = trimmedPhone;
+        }
+
+        if (typeof gender === "string") {
+            const loweredGender = gender.trim().toLowerCase();
+            if (["m", "erkek", "male"].includes(loweredGender)) {
+                customer.gender = "m";
+            } else if (["f", "k", "kadin", "kadın", "female"].includes(loweredGender)) {
+                customer.gender = "f";
+            }
+        }
+
+        if (typeof customerType === "string") {
+            const loweredType = customerType.trim().toLowerCase();
+            const allowedTypes = ["adult", "child", "student", "disabled", "retired"];
+            if (allowedTypes.includes(loweredType)) {
+                customer.customerType = loweredType;
+            }
+        }
+
+        if (typeof customerCategory === "string") {
+            const loweredCategory = customerCategory.trim().toLowerCase();
+            const allowedCategories = ["normal", "member"];
+            if (allowedCategories.includes(loweredCategory)) {
+                customer.customerCategory = loweredCategory;
+            }
+        }
+
+        if (pointOrPercent !== undefined) {
+            if (typeof pointOrPercent === "string") {
+                const lowered = pointOrPercent.trim().toLowerCase();
+                if (!lowered) {
+                    customer.pointOrPercent = null;
+                } else if (["point", "percent"].includes(lowered)) {
+                    customer.pointOrPercent = lowered;
+                }
+            } else if (pointOrPercent === null) {
+                customer.pointOrPercent = null;
+            }
+        }
+
+        if (pointAmount !== undefined) {
+            const parsedPointAmount = Number(pointAmount);
+            customer.point_amount = Number.isNaN(parsedPointAmount) ? 0 : parsedPointAmount;
+        }
+
+        if (percent !== undefined) {
+            const parsedPercent = Number(percent);
+            customer.percent = Number.isNaN(parsedPercent) ? 0 : parsedPercent;
+        }
+
+        await customer.save();
+
+        res.json({ success: true, customer: customer.toJSON() });
+    } catch (err) {
+        console.error("Customer update error:", err);
+        res.status(500).json({ success: false });
+    }
+};
+
 exports.getMemberTickets = async (req, res, next) => {
     try {
         const { idNumber } = req.query;

--- a/public/scripts/erp.js
+++ b/public/scripts/erp.js
@@ -6268,6 +6268,74 @@ $(".customers-close").on("click", e => {
     $(".customers").css("display", "none")
 })
 
+const openCustomerInfoPopup = (row, origin) => {
+    const popup = $(".member-info");
+    const id = row.data("id") || null;
+    const idNumber = row.data("idnumber") || "";
+    const name = row.data("name") || "";
+    const surname = row.data("surname") || "";
+    const phone = row.data("phone") || "";
+    const gender = row.data("gender") || "";
+    const type = row.data("customertype") || "";
+    const category = row.data("customercategory") || "";
+    const pointOrPercent = row.data("pointorpercent") || "";
+    const pointAmount = row.data("pointamount");
+    const percent = row.data("percent");
+
+    popup.data("customerId", id);
+    popup.data("origin", origin);
+    popup.data("sourceRow", row.get(0));
+
+    $(".member-info-idNumber").val(idNumber);
+    $(".member-info-name").val(name);
+    $(".member-info-surname").val(surname);
+    $(".member-info-phone").val(phone);
+    $(".member-info-gender").val(gender);
+    $(".member-info-type").val(type);
+    $(".member-info-category").val(category);
+    $(".member-info-pointorpercent").val(pointOrPercent);
+    const pointAmountValue = pointAmount === undefined || pointAmount === null ? "" : pointAmount;
+    const percentValue = percent === undefined || percent === null ? "" : percent;
+    $(".member-info-pointamount").val(pointAmountValue);
+    $(".member-info-percent").val(percentValue);
+
+    const saveBtn = $(".member-info-save");
+    if (!saveBtn.data("defaultText")) {
+        saveBtn.data("defaultText", saveBtn.text());
+    }
+    if (id) {
+        saveBtn.prop("disabled", false).text(saveBtn.data("defaultText"));
+    } else {
+        saveBtn.prop("disabled", true).text(saveBtn.data("defaultText"));
+    }
+
+    $(".members").css("display", "none");
+    $(".customers").css("display", "none");
+    popup.css("display", "block");
+    $(".blackout").css("display", "block");
+
+    $(".member-ticket-list").html("");
+    if (idNumber) {
+        $.ajax({
+            url: "/get-member-tickets",
+            type: "GET",
+            data: { idNumber },
+            success: function (resp) {
+                $(".member-ticket-list").html(resp);
+            },
+            error: function (xhr, status, error) {
+                console.log(error);
+            }
+        });
+    }
+};
+
+$(document).on("click", ".member-row, .customer-row", function () {
+    const row = $(this);
+    const origin = row.hasClass("member-row") ? "members" : "customers";
+    openCustomerInfoPopup(row, origin);
+});
+
 $(".member-nav").on("click", async e => {
     await $.ajax({
         url: "/get-members-list",
@@ -6277,46 +6345,6 @@ $(".member-nav").on("click", async e => {
             $(".member-list-nodes").html(response)
             $(".blackout").css("display", "block")
             $(".members").css("display", "block")
-
-            $(".member-row").on("click", function () {
-                const idNumber = $(this).data("idnumber");
-                const name = $(this).data("name");
-                const surname = $(this).data("surname");
-                const phone = $(this).data("phone");
-                const gender = $(this).data("gender");
-                const type = $(this).data("customertype");
-                const category = $(this).data("customercategory");
-                const pointOrPercent = $(this).data("pointorpercent");
-                const pointAmount = $(this).data("pointamount");
-                const percent = $(this).data("percent");
-
-                $(".member-info-idNumber").val(idNumber);
-                $(".member-info-name").val(name);
-                $(".member-info-surname").val(surname);
-                $(".member-info-phone").val(phone);
-                $(".member-info-gender").val(gender);
-                $(".member-info-type").val(type);
-                $(".member-info-category").val(category);
-                $(".member-info-pointorpercent").val(pointOrPercent);
-                $(".member-info-pointamount").val(pointAmount);
-                $(".member-info-percent").val(percent);
-
-                $(".members").css("display", "none");
-                $(".member-info").css("display", "block");
-                $(".blackout").css("display", "block");
-
-                $.ajax({
-                    url: "/get-member-tickets",
-                    type: "GET",
-                    data: { idNumber },
-                    success: function (resp) {
-                        $(".member-ticket-list").html(resp);
-                    },
-                    error: function (xhr, status, error) {
-                        console.log(error);
-                    }
-                });
-            });
         },
         error: function (xhr, status, error) {
             console.log(error);
@@ -6602,8 +6630,121 @@ $(".members-close").on("click", e => {
 })
 
 $(".member-info-close").on("click", e => {
-    $(".member-info").css("display", "none");
-    $(".members").css("display", "block");
+    const popup = $(".member-info");
+    const origin = popup.data("origin");
+    popup.css("display", "none");
+    if (origin === "members") {
+        $(".members").css("display", "block");
+    } else if (origin === "customers") {
+        $(".customers").css("display", "block");
+    } else {
+        $(".blackout").css("display", "none");
+    }
+});
+
+$(".member-info-save").on("click", async e => {
+    const popup = $(".member-info");
+    const customerId = popup.data("customerId");
+    if (!customerId) {
+        return;
+    }
+
+    const payload = {
+        id: customerId,
+        idNumber: $(".member-info-idNumber").val(),
+        name: $(".member-info-name").val(),
+        surname: $(".member-info-surname").val(),
+        phone: $(".member-info-phone").val(),
+        gender: $(".member-info-gender").val(),
+        customerType: $(".member-info-type").val(),
+        customerCategory: $(".member-info-category").val(),
+        pointOrPercent: $(".member-info-pointorpercent").val(),
+        pointAmount: $(".member-info-pointamount").val(),
+        percent: $(".member-info-percent").val()
+    };
+
+    const button = $(e.currentTarget);
+    if (!button.data("defaultText")) {
+        button.data("defaultText", button.text());
+    }
+    const defaultText = button.data("defaultText");
+    button.prop("disabled", true).text("Kaydediliyor...");
+
+    $.ajax({
+        url: "/post-update-customer",
+        type: "POST",
+        contentType: "application/json",
+        data: JSON.stringify(payload),
+        success: function (resp) {
+            button.text("Kaydedildi");
+            const updated = resp && resp.customer ? resp.customer : null;
+            if (updated) {
+                const valueOrEmpty = (value) => (value === undefined || value === null ? "" : value);
+                $(".member-info-idNumber").val(valueOrEmpty(updated.idNumber));
+                $(".member-info-name").val(valueOrEmpty(updated.name));
+                $(".member-info-surname").val(valueOrEmpty(updated.surname));
+                $(".member-info-phone").val(valueOrEmpty(updated.phoneNumber));
+                $(".member-info-gender").val(valueOrEmpty(updated.gender));
+                $(".member-info-type").val(valueOrEmpty(updated.customerType));
+                $(".member-info-category").val(valueOrEmpty(updated.customerCategory));
+                $(".member-info-pointorpercent").val(valueOrEmpty(updated.pointOrPercent));
+                $(".member-info-pointamount").val(valueOrEmpty(updated.point_amount));
+                $(".member-info-percent").val(valueOrEmpty(updated.percent));
+                popup.data("customerId", updated.id);
+
+                const sourceRowEl = popup.data("sourceRow");
+                if (sourceRowEl) {
+                    const sourceRow = $(sourceRowEl);
+                    sourceRow.data("idnumber", valueOrEmpty(updated.idNumber));
+                    sourceRow.data("name", valueOrEmpty(updated.name));
+                    sourceRow.data("surname", valueOrEmpty(updated.surname));
+                    sourceRow.data("phone", valueOrEmpty(updated.phoneNumber));
+                    sourceRow.data("gender", valueOrEmpty(updated.gender));
+                    sourceRow.data("customertype", valueOrEmpty(updated.customerType));
+                    sourceRow.data("customercategory", valueOrEmpty(updated.customerCategory));
+                    sourceRow.data("pointorpercent", valueOrEmpty(updated.pointOrPercent));
+                    sourceRow.data("pointamount", valueOrEmpty(updated.point_amount));
+                    sourceRow.data("percent", valueOrEmpty(updated.percent));
+
+                    if (sourceRow.hasClass("member-row")) {
+                        const cols = sourceRow.children();
+                        cols.eq(0).find("p").text(valueOrEmpty(updated.idNumber));
+                        cols.eq(1).find("p").text(valueOrEmpty(updated.name));
+                        cols.eq(2).find("p").text(valueOrEmpty(updated.surname));
+                        cols.eq(3).find("p").text(valueOrEmpty(updated.phoneNumber));
+                        const pointLabel = updated.pointOrPercent === "point" ? "Puan" : updated.pointOrPercent === "percent" ? "İndirim (%)" : "";
+                        const pointValue = updated.pointOrPercent === "point"
+                            ? `${valueOrEmpty(updated.point_amount) || 0} puan`
+                            : updated.pointOrPercent === "percent"
+                                ? `${valueOrEmpty(updated.percent) || 0}%`
+                                : "";
+                        cols.eq(4).find("p").text(pointLabel);
+                        cols.eq(5).find("p").text(pointValue);
+                    } else if (sourceRow.hasClass("customer-row")) {
+                        const cols = sourceRow.children();
+                        cols.eq(0).find("p").text(valueOrEmpty(updated.idNumber));
+                        cols.eq(1).find("p").text(valueOrEmpty(updated.name));
+                        cols.eq(2).find("p").text(valueOrEmpty(updated.surname));
+                        cols.eq(3).find("p").text(valueOrEmpty(updated.phoneNumber));
+                        const categoryCol = cols.eq(4).find("p");
+                        if (categoryCol.length) {
+                            categoryCol.text(updated.customerCategory === "member" ? "Abone" : "");
+                        }
+                    }
+                }
+            }
+            setTimeout(() => {
+                button.text(defaultText);
+            }, 2000);
+        },
+        error: function (xhr, status, error) {
+            console.log(error);
+            button.text(defaultText);
+        },
+        complete: function () {
+            button.prop("disabled", false);
+        }
+    });
 });
 
 function searchMembers() {

--- a/routes/erp.js
+++ b/routes/erp.js
@@ -124,6 +124,7 @@ router.get('/get-customer', erpController.getCustomer);
 router.get('/get-members-list', erpController.getMembersList);
 router.get('/get-member-tickets', erpController.getMemberTickets);
 router.post('/post-add-member', erpController.postAddMember);
+router.post('/post-update-customer', erpController.postUpdateCustomer);
 router.post('/post-customer-blacklist', erpController.postCustomerBlacklist);
 
 router.get('/get-transactions-list', auth, erpController.getTransactions);

--- a/views/erpscreen.pug
+++ b/views/erpscreen.pug
@@ -1524,34 +1524,35 @@ block content
             .member-info-left.p-3.d-flex.flex-column.gap-2
                 .input-group
                     span.input-group-text TC
-                    input.member-info-idNumber.form-control(type="text" readonly)
+                    input.member-info-idNumber.form-control(type="text")
                 .input-group
                     span.input-group-text İsim
-                    input.member-info-name.form-control(type="text" readonly)
+                    input.member-info-name.form-control(type="text")
                 .input-group
                     span.input-group-text Soyisim
-                    input.member-info-surname.form-control(type="text" readonly)
+                    input.member-info-surname.form-control(type="text")
                 .input-group
                     span.input-group-text Telefon
-                    input.member-info-phone.form-control(type="text" readonly)
+                    input.member-info-phone.form-control(type="text")
                 .input-group
                     span.input-group-text Cinsiyet
-                    input.member-info-gender.form-control(type="text" readonly)
+                    input.member-info-gender.form-control(type="text")
                 .input-group
                     span.input-group-text Tip
-                    input.member-info-type.form-control(type="text" readonly)
+                    input.member-info-type.form-control(type="text")
                 .input-group
                     span.input-group-text Kategori
-                    input.member-info-category.form-control(type="text" readonly)
+                    input.member-info-category.form-control(type="text")
                 .input-group
                     span.input-group-text Puan/İndirim
-                    input.member-info-pointorpercent.form-control(type="text" readonly)
+                    input.member-info-pointorpercent.form-control(type="text")
                 .input-group
                     span.input-group-text Puan
-                    input.member-info-pointamount.form-control(type="text" readonly)
+                    input.member-info-pointamount.form-control(type="text")
                 .input-group
                     span.input-group-text İndirim (%)
-                    input.member-info-percent.form-control(type="text" readonly)
+                    input.member-info-percent.form-control(type="text")
+                button.btn.btn-primary.member-info-save.mt-2 Kaydet
             .member-info-middle
             .member-info-right.p-3
                 .member-ticket-list.d-flex.flex-column.gap-2

--- a/views/mixins/customersList.pug
+++ b/views/mixins/customersList.pug
@@ -1,7 +1,20 @@
 each c in customers
     - const btnClass = c.isBlackList ? 'btn-outline-danger' : 'btn-outline-primary'
     .btn-group
-        button.d-flex.btn.col-11.customer-row(class=`${btnClass} ${permissions.includes('TRIP_BLACKLIST_MANAGE')?"col-11":"col-12"}`)
+        button.d-flex.btn.col-11.customer-row(
+            class=`${btnClass} ${permissions.includes('TRIP_BLACKLIST_MANAGE')?"col-11":"col-12"}`
+            data-id=c.id
+            data-idnumber=c.idNumber
+            data-name=c.name
+            data-surname=c.surname
+            data-phone=c.phoneNumber
+            data-gender=c.gender
+            data-customertype=c.customerType
+            data-customercategory=c.customerCategory
+            data-pointorpercent=c.pointOrPercent
+            data-pointamount=c.point_amount
+            data-percent=c.percent
+        )
             .col-2
                 p.text-center.m-0 #{c.idNumber}
             div(class=`${blacklist == "true"?"col-2":"col-3"}`)


### PR DESCRIPTION
## Summary
- allow both member and customer list rows to open the shared customer detail popup and edit fields
- add a save action that updates customer records via AJAX and refreshes the list row data
- expose a backend endpoint to persist customer field updates

## Testing
- Not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68e19b0632588322963885615a5b586e