### PR TITLE
Adjust customer popup selects and discounts

### DIFF
--- a/routes/erp.js
+++ b/routes/erp.js
@@ -124,6 +124,7 @@ router.get('/get-customer', erpController.getCustomer);
 router.get('/get-members-list', erpController.getMembersList);
 router.get('/get-member-tickets', erpController.getMemberTickets);
 router.post('/post-add-member', erpController.postAddMember);
+router.post('/post-update-customer', erpController.postUpdateCustomer);
 router.post('/post-customer-blacklist', erpController.postCustomerBlacklist);
 
 router.get('/get-transactions-list', auth, erpController.getTransactions);

--- a/views/erpscreen.pug
+++ b/views/erpscreen.pug
@@ -1515,6 +1515,11 @@ block content
                     p.text-center.m-0 Puan veya İnd. Oranı
             .member-list-nodes.d-flex.flex-column.gap-3
 
+    -
+        const genderOptions = (customerFieldOptions && customerFieldOptions.gender) || [];
+        const customerTypeOptions = (customerFieldOptions && customerFieldOptions.customerType) || [];
+        const customerCategoryOptions = (customerFieldOptions && customerFieldOptions.customerCategory) || [];
+        const pointOrPercentOptions = (customerFieldOptions && customerFieldOptions.pointOrPercent) || [];
     .member-info
         .gtr-header
             span ABONE BİLGİLERİ
@@ -1524,34 +1529,47 @@ block content
             .member-info-left.p-3.d-flex.flex-column.gap-2
                 .input-group
                     span.input-group-text TC
-                    input.member-info-idNumber.form-control(type="text" readonly)
+                    input.member-info-idNumber.form-control(type="text")
                 .input-group
                     span.input-group-text İsim
-                    input.member-info-name.form-control(type="text" readonly)
+                    input.member-info-name.form-control(type="text")
                 .input-group
                     span.input-group-text Soyisim
-                    input.member-info-surname.form-control(type="text" readonly)
+                    input.member-info-surname.form-control(type="text")
                 .input-group
                     span.input-group-text Telefon
-                    input.member-info-phone.form-control(type="text" readonly)
+                    input.member-info-phone.form-control(type="text")
                 .input-group
                     span.input-group-text Cinsiyet
-                    input.member-info-gender.form-control(type="text" readonly)
+                    select.member-info-gender.form-select
+                        option(value="") Seçiniz
+                        each option in genderOptions
+                            option(value=option.value)= option.label
                 .input-group
                     span.input-group-text Tip
-                    input.member-info-type.form-control(type="text" readonly)
+                    select.member-info-type.form-select
+                        option(value="") Seçiniz
+                        each option in customerTypeOptions
+                            option(value=option.value)= option.label
                 .input-group
                     span.input-group-text Kategori
-                    input.member-info-category.form-control(type="text" readonly)
+                    select.member-info-category.form-select
+                        option(value="") Seçiniz
+                        each option in customerCategoryOptions
+                            option(value=option.value)= option.label
                 .input-group
                     span.input-group-text Puan/İndirim
-                    input.member-info-pointorpercent.form-control(type="text" readonly)
+                    select.member-info-pointorpercent.form-select
+                        option(value="") Seçiniz
+                        each option in pointOrPercentOptions
+                            option(value=option.value)= option.label
                 .input-group
                     span.input-group-text Puan
-                    input.member-info-pointamount.form-control(type="text" readonly)
+                    input.member-info-pointamount.form-control(type="text")
                 .input-group
                     span.input-group-text İndirim (%)
-                    input.member-info-percent.form-control(type="text" readonly)
+                    input.member-info-percent.form-control(type="text")
+                button.btn.btn-primary.member-info-save.mt-2 Kaydet
             .member-info-middle
             .member-info-right.p-3
                 .member-ticket-list.d-flex.flex-column.gap-2

--- a/views/mixins/customersList.pug
+++ b/views/mixins/customersList.pug
@@ -1,7 +1,20 @@
 each c in customers
     - const btnClass = c.isBlackList ? 'btn-outline-danger' : 'btn-outline-primary'
     .btn-group
-        button.d-flex.btn.col-11.customer-row(class=`${btnClass} ${permissions.includes('TRIP_BLACKLIST_MANAGE')?"col-11":"col-12"}`)
+        button.d-flex.btn.col-11.customer-row(
+            class=`${btnClass} ${permissions.includes('TRIP_BLACKLIST_MANAGE')?"col-11":"col-12"}`
+            data-id=c.id
+            data-idnumber=c.idNumber
+            data-name=c.name
+            data-surname=c.surname
+            data-phone=c.phoneNumber
+            data-gender=c.gender
+            data-customertype=c.customerType
+            data-customercategory=c.customerCategory
+            data-pointorpercent=c.pointOrPercent
+            data-pointamount=c.point_amount
+            data-percent=c.percent
+        )
             .col-2
                 p.text-center.m-0 #{c.idNumber}
             div(class=`${blacklist == "true"?"col-2":"col-3"}`)


### PR DESCRIPTION
## Summary
- populate customer popup select options from the Customer model enums so labels stay in sync with allowed values
- render gender, type, category, and discount mode as selects in the popup and update the front-end logic to respect their selections
- disable point and percent inputs dynamically based on the selected discount mode for clearer editing

## Testing
- Not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68e19b0632588322963885615a5b586e