### PR TITLE
Handle missing trip navigation for member tickets

### DIFF
--- a/public/scripts/erp.js
+++ b/public/scripts/erp.js
@@ -174,6 +174,38 @@ const showError = message => {
 
 window.showError = showError;
 
+const clearMemberTicketFeedback = $element => {
+    if (!$element || !$element.length) {
+        return;
+    }
+
+    const $footer = $element.closest(".member-ticket-footer");
+    if (!$footer.length) {
+        return;
+    }
+
+    $footer.find(".member-ticket-feedback").remove();
+};
+
+const showMemberTicketFeedback = ($element, message) => {
+    if (!$element || !$element.length) {
+        return;
+    }
+
+    const $footer = $element.closest(".member-ticket-footer");
+    if (!$footer.length) {
+        return;
+    }
+
+    let $feedback = $footer.find(".member-ticket-feedback");
+    if (!$feedback.length) {
+        $feedback = $("<span>", { class: "member-ticket-feedback text-muted", role: "status" });
+        $footer.append($feedback);
+    }
+
+    $feedback.text(message || "");
+};
+
 $(".error-close").off().on("click", () => $(".error-popup").hide());
 
 const setupDeleteHandler = (selector, { url, getData, getConfirmMessage, onSuccess }) => {
@@ -6177,6 +6209,60 @@ const openCustomerInfoPopup = (row, origin) => {
         });
     }
 };
+
+$(document).on("click", ".member-ticket-go-trip", async function (e) {
+    e.preventDefault();
+
+    const $btn = $(this);
+    clearMemberTicketFeedback($btn);
+    const tripId = $btn.data("tripId");
+    const tripDate = $btn.data("tripDate");
+    const tripTime = $btn.data("tripTime");
+
+    if (!tripId || !tripDate || !tripTime) {
+        showMemberTicketFeedback($btn, "Bu bilet için aktif bir sefer bulunamadı.");
+        return;
+    }
+
+    const previousTripState = {
+        id: currentTripId,
+        date: currentTripDate,
+        time: currentTripTime
+    };
+
+    $btn.prop("disabled", true);
+
+    try {
+        await loadTrip(tripDate, tripTime, tripId);
+
+        currentTripId = tripId;
+        currentTripDate = tripDate;
+        currentTripTime = tripTime;
+
+        $(".member-info").css("display", "none");
+        $(".blackout").css("display", "none");
+    } catch (error) {
+        currentTripId = previousTripState.id;
+        currentTripDate = previousTripState.date;
+        currentTripTime = previousTripState.time;
+
+        const status = error?.status || error?.statusCode || error?.responseJSON?.status;
+        const errorCode = error?.responseJSON?.code || error?.responseJSON?.errorCode;
+        const notFound = status === 404 || errorCode === "TRIP_NOT_FOUND";
+
+        if (notFound) {
+            const fallbackMessage = "Bu bilet için aktif bir sefer bulunamadı.";
+            const message = error?.responseJSON?.message || fallbackMessage;
+            console.warn("Trip not found for ticket", { tripId, tripDate, tripTime, error });
+            showMemberTicketFeedback($btn, message);
+        } else {
+            console.error(error);
+            showError("Sefer bilgisi yüklenemedi.");
+        }
+    } finally {
+        $btn.prop("disabled", false);
+    }
+});
 
 $(".customer-nav").on("click", async e => {
     await $.ajax({

--- a/public/stylesheets/erpscreen.css
+++ b/public/stylesheets/erpscreen.css
@@ -778,6 +778,152 @@ select.price-button-select {
 .member-ticket-list {
     max-height: 60vh;
     overflow-y: auto;
+    background: #f8fafc;
+    border-radius: 0.75rem;
+    padding: 1rem;
+    border: 1px solid #e2e6ea;
+    box-shadow: 0 1rem 2.5rem rgba(15, 23, 42, 0.08);
+    gap: 1rem !important;
+}
+
+.member-ticket-list::-webkit-scrollbar {
+    width: 6px;
+}
+
+.member-ticket-list::-webkit-scrollbar-thumb {
+    background-color: rgba(15, 23, 42, 0.25);
+    border-radius: 999px;
+}
+
+.member-ticket-list::-webkit-scrollbar-track {
+    background: transparent;
+}
+
+.member-ticket-card {
+    background: #ffffff;
+    border-radius: 0.85rem;
+    padding: 1rem 1.25rem;
+    border: 1px solid #e5e7eb;
+    box-shadow: 0 0.75rem 1.75rem rgba(15, 23, 42, 0.05);
+    display: flex;
+    flex-direction: column;
+    gap: 0.75rem;
+    transition: transform 0.2s ease, box-shadow 0.2s ease;
+}
+
+.member-ticket-card:hover {
+    transform: translateY(-2px);
+    box-shadow: 0 1rem 2rem rgba(15, 23, 42, 0.12);
+}
+
+.member-ticket-header {
+    display: flex;
+    justify-content: space-between;
+    gap: 0.75rem;
+    flex-wrap: wrap;
+    align-items: center;
+}
+
+.member-ticket-route {
+    display: inline-flex;
+    align-items: center;
+    gap: 0.75rem;
+    font-weight: 600;
+    color: #1f2937;
+    letter-spacing: 0.01em;
+}
+
+.member-ticket-route-text {
+    font-size: 1rem;
+    text-transform: capitalize;
+}
+
+.member-ticket-route-arrow {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    color: #0d6efd;
+    font-size: 1rem;
+}
+
+.member-ticket-pnr {
+    font-size: 0.85rem;
+    font-weight: 500;
+    color: #64748b;
+    letter-spacing: 0.08em;
+}
+
+.member-ticket-meta {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 0.65rem;
+    color: #475569;
+    font-size: 0.9rem;
+}
+
+.member-ticket-meta-item {
+    display: inline-flex;
+    align-items: center;
+    gap: 0.4rem;
+    background: rgba(13, 110, 253, 0.08);
+    color: #1e293b;
+    padding: 0.25rem 0.6rem;
+    border-radius: 999px;
+    line-height: 1.2;
+}
+
+.member-ticket-meta-item i {
+    font-size: 0.75rem;
+    color: #0d6efd;
+}
+
+.member-ticket-footer {
+    display: flex;
+    align-items: center;
+    gap: 0.75rem;
+    flex-wrap: wrap;
+}
+
+.member-ticket-price {
+    font-size: 1.05rem;
+    font-weight: 700;
+    color: #0d6efd;
+}
+
+.member-ticket-go-trip {
+    display: inline-flex;
+    align-items: center;
+    gap: 0.35rem;
+    text-transform: uppercase;
+    letter-spacing: 0.05em;
+}
+
+.member-ticket-go-trip.disabled,
+.member-ticket-go-trip:disabled {
+    cursor: not-allowed;
+    opacity: 0.6;
+}
+
+.member-ticket-feedback {
+    font-size: 0.85rem;
+    color: #64748b;
+    display: inline-flex;
+    align-items: center;
+    gap: 0.35rem;
+}
+
+.member-ticket-feedback::before {
+    content: "\2139";
+    font-size: 0.9rem;
+}
+
+.member-ticket-missing {
+    font-size: 0.85rem;
+}
+
+.member-ticket-empty {
+    background: rgba(15, 23, 42, 0.04);
+    border-radius: 0.85rem;
 }
 
 .customers button {

--- a/views/mixins/memberTickets.pug
+++ b/views/mixins/memberTickets.pug
@@ -1,9 +1,35 @@
 if tickets.length
     each t in tickets
-        .d-flex.justify-content-between.border-bottom.py-1
-            span #{t.date}
-            span #{t.from} - #{t.to}
-            span #{t.pnr}
-            span #{t.price}
+        .member-ticket-card
+            .member-ticket-header
+                .member-ticket-route
+                    span.member-ticket-route-text #{t.from || 'Belirtilmedi'}
+                    span.member-ticket-route-arrow
+                        i.fa-solid.fa-angles-right
+                    span.member-ticket-route-text #{t.to || 'Belirtilmedi'}
+                span.member-ticket-pnr PNR: #{t.pnr || '-'}
+            .member-ticket-meta
+                if t.tripDateDisplay || t.tripTimeDisplay
+                    span.member-ticket-meta-item
+                        i.fa-solid.fa-calendar-days
+                        span #{[t.tripDateDisplay, t.tripTimeDisplay].filter(Boolean).join(' • ')}
+                if t.seatNo
+                    span.member-ticket-meta-item
+                        i.fa-solid.fa-chair
+                        span Koltuk: #{t.seatNo}
+                if t.purchaseDateDisplay
+                    span.member-ticket-meta-item
+                        i.fa-solid.fa-clock
+                        span Satın Alma: #{t.purchaseDateDisplay}
+            .member-ticket-footer
+                span.member-ticket-price #{t.priceDisplay || '-'}
+                - const hasTripData = Boolean(t.tripId && t.tripDate && t.tripTime)
+                button.member-ticket-go-trip.btn.btn-outline-primary.btn-sm(type="button", data-trip-id=hasTripData ? t.tripId : null, data-trip-date=hasTripData ? t.tripDate : null, data-trip-time=hasTripData ? t.tripTime : null, disabled=hasTripData ? null : true)
+                    i.fa-solid.fa-route.me-1
+                    | Sefere Git
+                if !hasTripData
+                    span.member-ticket-missing.text-muted Sefer bilgisi bulunamadı
 else
-    p.text-center.m-0 Kayıt bulunamadı
+    .member-ticket-empty.text-center.py-4.text-muted
+        i.fa-regular.fa-ticket.me-2
+        | Kayıtlı bilet bulunamadı


### PR DESCRIPTION
## Summary
- guard the "Sefere Git" action against missing trip metadata and show inline feedback instead of an error popup
- surface a contextual message in the ticket card when the trip lookup returns 404 (open ticket) and keep the member popup visible
- style the new inline feedback indicator to match the refreshed ticket card design

## Testing
- npm start *(fails: Cannot find module './utilities/goturDB')*

------
https://chatgpt.com/codex/tasks/task_e_68e1a460c82c8322a3a29b63272f5e17