### PR TITLE
Fix price editor data handling and prevent ticket price changes

### DIFF
--- a/views/erpscreen.pug
+++ b/views/erpscreen.pug
@@ -1173,35 +1173,35 @@ block content
                     p.text-center.m-0 Nezamana
             .d-flex.btn.btn-primary.price-button-inputs.price-add-row
                 .col
-                    select.price-button-select
+                    select.price-button-select(data-field="fromStopId")
                 .col
-                    select.price-button-select
+                    select.price-button-select(data-field="toStopId")
                 .col.d-flex.justify-content-center.align-items-center
-                    input.price-bidirectional.form-check-input(type="checkbox")
+                    input.price-bidirectional.form-check-input(type="checkbox" data-field="isBidirectional")
                 .col
-                    input.price-button-input(type="text" value="")
+                    input.price-button-input(type="text" value="" data-field="price1")
                 .col
-                    input.price-button-input(type="text" value="")
+                    input.price-button-input(type="text" value="" data-field="price2")
                 .col
-                    input.price-button-input(type="text" value="")
+                    input.price-button-input(type="text" value="" data-field="price3")
                 .col
-                    input.price-button-input(type="text" value="")
+                    input.price-button-input(type="text" value="" data-field="webPrice")
                 .col
-                    input.price-button-input(type="text" value="")
+                    input.price-button-input(type="text" value="" data-field="singleSeatPrice1")
                 .col
-                    input.price-button-input(type="text" value="")
+                    input.price-button-input(type="text" value="" data-field="singleSeatPrice2")
                 .col
-                    input.price-button-input(type="text" value="")
+                    input.price-button-input(type="text" value="" data-field="singleSeatPrice3")
                 .col
-                    input.price-button-input(type="text" value="")
+                    input.price-button-input(type="text" value="" data-field="singleSeatWebPrice")
                 .col
-                    input.price-button-input(type="text" value="")
+                    input.price-button-input(type="text" value="" data-field="seatLimit")
                 .col
-                    input.price-button-input.hour-limit(type="number" value="")
+                    input.price-button-input.hour-limit(type="number" value="" data-field="hourLimit")
                 .col
-                    input.price-button-input.date-picker(type="text" value="")
+                    input.price-button-input.date-picker(type="text" value="" data-field="validFrom")
                 .col
-                    input.price-button-input.date-picker(type="text" value="")
+                    input.price-button-input.date-picker(type="text" value="" data-field="validUntil")
         .p-3.d-flex.gap-3.justify-content-end
             button.btn.btn-outline-primary.price-add-save KAYDET
             button.btn.btn-outline-primary.price-add-save-continue KAYDET VE DEVAM ET

--- a/views/mixins/pricesList.pug
+++ b/views/mixins/pricesList.pug
@@ -3,34 +3,34 @@ each p in prices
     .btn-group.w-100
         button.price-row.d-flex.btn.btn-outline-primary.col-11(type="button" data-id=p.id data-from=p.fromTitle data-to=p.toTitle)
             .col
-                p.text-center.m-0(data-value=p.fromStopId) #{p.fromTitle}
+                p.text-center.m-0(data-field="fromStopId" data-value=p.fromStopId) #{p.fromTitle}
             .col
-                p.text-center.m-0(data-value=p.toStopId) #{p.toTitle}
+                p.text-center.m-0(data-field="toStopId" data-value=p.toStopId) #{p.toTitle}
             .col
-                p.text-center.m-0(data-value=p.isBidirectional) #{p.isBidirectional ? "Evet" : "Hayır"}
+                p.text-center.m-0(data-field="isBidirectional" data-value=p.isBidirectional) #{p.isBidirectional ? "Evet" : "Hayır"}
             .col
-                p.text-center.m-0 #{p.price1}
+                p.text-center.m-0(data-field="price1" data-value=p.price1) #{p.price1}
             .col
-                p.text-center.m-0 #{p.price2}
+                p.text-center.m-0(data-field="price2" data-value=p.price2) #{p.price2}
             .col
-                p.text-center.m-0 #{p.price3}
+                p.text-center.m-0(data-field="price3" data-value=p.price3) #{p.price3}
             .col
-                p.text-center.m-0 #{p.webPrice}
+                p.text-center.m-0(data-field="webPrice" data-value=p.webPrice) #{p.webPrice}
             .col
-                p.text-center.m-0 #{p.singleSeatPrice1}
+                p.text-center.m-0(data-field="singleSeatPrice1" data-value=p.singleSeatPrice1) #{p.singleSeatPrice1}
             .col
-                p.text-center.m-0 #{p.singleSeatPrice2}
+                p.text-center.m-0(data-field="singleSeatPrice2" data-value=p.singleSeatPrice2) #{p.singleSeatPrice2}
             .col
-                p.text-center.m-0 #{p.singleSeatPrice3}
+                p.text-center.m-0(data-field="singleSeatPrice3" data-value=p.singleSeatPrice3) #{p.singleSeatPrice3}
             .col
-                p.text-center.m-0 #{p.singleSeatWebPrice}
-            //- .col
-            //-     p.text-center.m-0 #{p.seatLimit}
-            //- .col
-            //-     p.text-center.m-0(data-value=p.hourLimit) #{p.hourLimit}
+                p.text-center.m-0(data-field="singleSeatWebPrice" data-value=p.singleSeatWebPrice) #{p.singleSeatWebPrice}
+            .col.d-none
+                p.text-center.m-0(data-field="seatLimit" data-value=p.seatLimit) #{p.seatLimit}
+            .col.d-none
+                p.text-center.m-0(data-field="hourLimit" data-value=p.hourLimit) #{p.hourLimit}
             .col
-                p.text-center.m-0(data-value=p.validFrom) #{p.validFrom}
+                p.text-center.m-0(data-field="validFrom" data-value=p.validFromRaw) #{p.validFrom}
             .col
-                p.text-center.m-0(data-value=p.validUntil) #{p.validUntil}
+                p.text-center.m-0(data-field="validUntil" data-value=p.validUntilRaw) #{p.validUntil}
         button.btn.btn-outline-danger.price-delete.col-1(type="button" data-id=p.id data-from=p.fromTitle data-to=p.toTitle)
             i.fa-solid.fa-trash

--- a/views/mixins/ticketRow.pug
+++ b/views/mixins/ticketRow.pug
@@ -71,29 +71,34 @@
                 if ((permissions && permissions.includes('SALE_DISCOUNT_TICKET_OWN_BRANCH') && isOwnBranch) || (permissions && permissions.includes('SALE_DISCOUNT_TICKET_OTHER_BRANCH') && !isOwnBranch))
                     option(value="member") Abone
                     option(value="guest") Misafir
-        if price
-            -
-                const seatPriceData = Array.isArray(price) ? price[i] : price
-                const seatType = (seatTypes && seatTypes[i] == "single") ? "single" : "standard"
-                const regularPriceValues = []
-                const singleSeatPriceValues = []
+        -
+            const seatPriceData = price ? (Array.isArray(price) ? price[i] : price) : null
+            const seatType = (seatTypes && seatTypes[i] == "single") ? "single" : "standard"
+            const regularPriceValues = []
+            const singleSeatPriceValues = []
+            const ticketPriceRaw = ticket && ticket[i] ? ticket[i].price : null
+            const ticketPriceNumber = Number(ticketPriceRaw)
+            const hasTicketPriceValue = ticketPriceRaw !== null && ticketPriceRaw !== undefined && ticketPriceRaw !== "" && !Number.isNaN(ticketPriceNumber)
 
-                if (seatPriceData && seatPriceData.price1 != null) regularPriceValues.push(seatPriceData.price1)
-                if (seatPriceData && seatPriceData.price2 != null) regularPriceValues.push(seatPriceData.price2)
-                if (seatPriceData && seatPriceData.price3 != null) regularPriceValues.push(seatPriceData.price3)
-                if (seatPriceData && seatPriceData.singleSeatPrice1 != null) singleSeatPriceValues.push(seatPriceData.singleSeatPrice1)
-                if (seatPriceData && seatPriceData.singleSeatPrice2 != null) singleSeatPriceValues.push(seatPriceData.singleSeatPrice2)
-                if (seatPriceData && seatPriceData.singleSeatPrice3 != null) singleSeatPriceValues.push(seatPriceData.singleSeatPrice3)
+            if (seatPriceData && seatPriceData.price1 != null) regularPriceValues.push(seatPriceData.price1)
+            if (seatPriceData && seatPriceData.price2 != null) regularPriceValues.push(seatPriceData.price2)
+            if (seatPriceData && seatPriceData.price3 != null) regularPriceValues.push(seatPriceData.price3)
+            if (seatPriceData && seatPriceData.singleSeatPrice1 != null) singleSeatPriceValues.push(seatPriceData.singleSeatPrice1)
+            if (seatPriceData && seatPriceData.singleSeatPrice2 != null) singleSeatPriceValues.push(seatPriceData.singleSeatPrice2)
+            if (seatPriceData && seatPriceData.singleSeatPrice3 != null) singleSeatPriceValues.push(seatPriceData.singleSeatPrice3)
 
-                const activePriceList = (seatType === "single")
-                    ? (singleSeatPriceValues.length ? singleSeatPriceValues : regularPriceValues)
-                    : (regularPriceValues.length ? regularPriceValues : singleSeatPriceValues)
+            const activePriceList = (seatType === "single")
+                ? (singleSeatPriceValues.length ? singleSeatPriceValues : regularPriceValues)
+                : (regularPriceValues.length ? regularPriceValues : singleSeatPriceValues)
 
-                const defaultPriceValue = (ticket && ticket[i] && ticket[i].price != null)
-                    ? ticket[i].price
-                    : (activePriceList.length ? activePriceList[0] : "")
+            const defaultPriceValue = hasTicketPriceValue
+                ? ticketPriceRaw
+                : (activePriceList.length ? activePriceList[0] : "")
 
-                const showPriceArrows = activePriceList.length > 1
+            const showPriceArrows = activePriceList.length > 1
+            const shouldLockPriceInput = (action === "edit") && hasTicketPriceValue
+            const canEnterFreePrice = permissions && permissions.includes('ENTER_FREE_PRICE')
+            const inputIsReadonly = !canEnterFreePrice || shouldLockPriceInput
         .price(
             data-seat-type=seatType
             data-regular-prices=JSON.stringify(regularPriceValues)
@@ -103,10 +108,7 @@
                 | Fiyat
                 span.customer-point.ms-1
             .price-input-wrapper
-                if !permissions.includes('ENTER_FREE_PRICE')
-                    input.form-control.form-control-sm(readonly type="number" value=defaultPriceValue)
-                else
-                    input.form-control.form-control-sm(type="number" value=defaultPriceValue)
+                input.form-control.form-control-sm(type="number" value=defaultPriceValue readonly=inputIsReadonly ? true : false)
                 if showPriceArrows
                     .price-arrows.btn-group-vertical.ms-1
                         button.price-arrow.price-arrow-up.btn.btn-outline-secondary.btn-sm(type="button")


### PR DESCRIPTION
## Summary
- fix the price list UI by tracking field metadata, collecting values safely, and exposing raw date data
- disable changing ticket prices during edit while still showing stored values and enforcing the rule on the backend
- add field metadata to the price add popup so new prices reuse the same data handling helpers

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68e2c7eab66883228082999bd785cb32