### PR TITLE
Adjust ticket row overflow behavior

### DIFF
--- a/public/stylesheets/erpscreen.css
+++ b/public/stylesheets/erpscreen.css
@@ -1481,8 +1481,8 @@ div.ticket-cancel-refund-open-close {
     flex-direction: column;
     gap: .5rem;
     padding: .5rem 0;
-    max-height: 95vh;
-    overflow-y: auto;
+    max-height: none;
+    overflow: visible;
 }
 
 .ticket-rows input,


### PR DESCRIPTION
## Summary
- allow ticket rows to overflow instead of forcing scrollbars
- remove the restrictive max-height so dropdowns such as searchable-selects can extend beyond the container

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e2ccfdee00832295240cc712a31851