### PR TITLE
Soft delete stops and cascade related records

### DIFF
--- a/models/routeModel.js
+++ b/models/routeModel.js
@@ -43,5 +43,10 @@ module.exports = (sequelize) => {
       type: DataTypes.INTEGER,
       allowNull: true,
     },
+    isDeleted: {
+      type: DataTypes.BOOLEAN,
+      allowNull: false,
+      defaultValue: false,
+    },
   });
 };

--- a/models/stopModel.js
+++ b/models/stopModel.js
@@ -33,5 +33,10 @@ module.exports = (sequelize) => {
       allowNull: false,
       defaultValue: true,
     },
+    isDeleted: {
+      type: DataTypes.BOOLEAN,
+      allowNull: false,
+      defaultValue: false,
+    },
   });
 };

--- a/models/tripModel.js
+++ b/models/tripModel.js
@@ -65,5 +65,10 @@ module.exports = (sequelize) => {
     busPlanString: {
       type: DataTypes.STRING,
     },
+    isDeleted: {
+      type: DataTypes.BOOLEAN,
+      allowNull: false,
+      defaultValue: false,
+    },
   });
 };

--- a/public/scripts/erp.js
+++ b/public/scripts/erp.js
@@ -4989,9 +4989,8 @@ $(document)
         e.stopPropagation()
 
         const $button = $(this)
-        const title = $button.data("title")
-        const message = `${title || "Bu durağı"} silmek istediğinize emin misiniz?`
-        if (message && !window.confirm(message)) {
+        const warningMessage = "Bu durağı silerseniz bu durağı kullanan hatlar, şubeler, bu şubelerin kullanıcıları ve seferler de silinecektir."
+        if (!window.confirm(warningMessage)) {
             return
         }
 

--- a/views/mixins/stopsList.pug
+++ b/views/mixins/stopsList.pug
@@ -1,6 +1,9 @@
 each s in stops
-    button.stop-button.d-flex.btn.btn-outline-primary(type="button" data-id=s.id)
-        .col-6
-            p.text-center.m-0 #{s.title}
-        .col-6
-            p.text-center.m-0 #{s.placeTitle}
+    .btn-group.w-100
+        button.stop-button.d-flex.btn.btn-outline-primary.col-11(type="button" data-id=s.id data-title=s.title)
+            .col-6
+                p.text-center.m-0 #{s.title}
+            .col-6
+                p.text-center.m-0 #{s.placeTitle}
+        button.btn.btn-outline-danger.stop-delete.col-1(type="button" data-id=s.id data-title=s.title)
+            i.fa-solid.fa-trash


### PR DESCRIPTION
## Summary
- add an `isDeleted` flag to stop, route, and trip models
- filter stop listings to active records and render a delete control with a warning
- perform soft deletion for stops while cascading the flag to related routes, trips, branches, and firm users

## Testing
- not run (not provided)


------
https://chatgpt.com/codex/tasks/task_e_68e2edf596288322bf00ccee481cdb65