### PR TITLE
Soft delete buses and update trip references

### DIFF
--- a/models/busModel.js
+++ b/models/busModel.js
@@ -67,6 +67,11 @@ module.exports = (sequelize) => {
       allowNull: false,
       defaultValue: false,
     },
+    isDeleted: {
+      type: DataTypes.BOOLEAN,
+      allowNull: false,
+      defaultValue: false,
+    },
     customCommissionRate: {
       type: DataTypes.DECIMAL(10, 2),
       allowNull: true,

--- a/public/scripts/erp.js
+++ b/public/scripts/erp.js
@@ -4695,6 +4695,7 @@ $(document)
 
         const $button = $(this)
         const plate = $button.data("plate")
+        window.alert("Bu otobüsü silerseniz bunu kullanan seferler de etkilenecektir.")
         const message = `${plate || "Bu otobüsü"} silmek istediğinize emin misiniz?`
         if (message && !window.confirm(message)) {
             return


### PR DESCRIPTION
## Summary
- add an isDeleted flag to the bus model to support soft deletion
- hide deleted buses from the ERP bus list and supporting data endpoints
- soft delete buses through the controller and null out related trip bus assignments
- inform users about the cascading impact when attempting to delete a bus

## Testing
- Not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68e2ef0cdb8c8322862eb56d1a10d227