### PR TITLE
Enable trip list cancel/activate buttons

### DIFF
--- a/views/mixins/tripsList.pug
+++ b/views/mixins/tripsList.pug
@@ -1,6 +1,6 @@
 each t in trips
     .btn-group
-        button.trip-button.d-flex.btn(class=`${t.isActive?"btn-outline-primary":"btn-danger"} ${permissions.includes('TRIP_CANCEL')?"col-11":"col-12"}` data-id=t.id data-time=t.time)
+        button.trip-button.d-flex.btn(type="button" class=`${t.isActive?"btn-outline-primary":"btn-danger"} ${permissions.includes('TRIP_CANCEL')?"col-11":"col-12"}` data-id=t.id data-time=t.time)
             .col-2
                 p.text-center.m-0 #{t.time}
             .col-2
@@ -15,8 +15,8 @@ each t in trips
                 p.text-center.m-0 #{t.routeTitle}
         if permissions.includes('TRIP_CANCEL')
             if t.isActive
-                button.trip-cancel-button.btn.btn-outline-danger.col-1
+                button.trip-cancel-button.btn.btn-outline-danger.col-1(type="button" data-trip-id=t.id data-trip-date=t.date data-trip-time=t.time)
                     i.fa-solid.fa-ban
             else
-                button.trip-active-button.btn.btn-outline-primary.col-1
+                button.trip-active-button.btn.btn-outline-primary.col-1(type="button" data-trip-id=t.id data-trip-date=t.date data-trip-time=t.time)
                     i.fa-regular.fa-circle


### PR DESCRIPTION
## Summary
- add data attributes to trip list action buttons so the client knows which trip to update
- bind trip cancel/activate buttons on the list to the existing activation endpoint and refresh the UI after toggles

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68e2ee9327788322937c5a264fffc64b