### PR TITLE
Add Enter key navigation for ticket row inputs

### DIFF
--- a/public/scripts/erp.js
+++ b/public/scripts/erp.js
@@ -144,6 +144,85 @@ function initializeTicketRowPriceControls() {
     }
 }
 
+function getFocusableTicketRowInputs($row) {
+    return $row
+        .find("input")
+        .filter(function () {
+            const $input = $(this);
+            const type = ($input.attr("type") || "").toLowerCase();
+
+            if (type === "hidden") {
+                return false;
+            }
+
+            if ($input.is(":disabled")) {
+                return false;
+            }
+
+            if (!$input.is(":visible")) {
+                return false;
+            }
+
+            return true;
+        });
+}
+
+function focusNextTicketRowInput(currentInput) {
+    const $current = $(currentInput);
+    const $row = $current.closest(".ticket-row");
+
+    if (!$row.length) {
+        return;
+    }
+
+    const $inputs = getFocusableTicketRowInputs($row);
+    const currentIndex = $inputs.index($current);
+
+    if (currentIndex === -1) {
+        return;
+    }
+
+    const $nextInput = $inputs.eq(currentIndex + 1);
+
+    if ($nextInput.length) {
+        $nextInput.trigger("focus");
+        if (typeof $nextInput[0].select === "function") {
+            $nextInput[0].select();
+        }
+        return;
+    }
+
+    const $nextRow = $row.next(".ticket-row");
+
+    if (!$nextRow.length) {
+        return;
+    }
+
+    const $firstInput = getFocusableTicketRowInputs($nextRow).first();
+
+    if ($firstInput.length) {
+        $firstInput.trigger("focus");
+        if (typeof $firstInput[0].select === "function") {
+            $firstInput[0].select();
+        }
+    }
+}
+
+$(document).off("keydown.ticketRowEnter").on("keydown.ticketRowEnter", ".ticket-row input", function (event) {
+    if (event.key !== "Enter") {
+        return;
+    }
+
+    const type = ($(event.currentTarget).attr("type") || "").toLowerCase();
+
+    if (type === "radio") {
+        return;
+    }
+
+    event.preventDefault();
+    focusNextTicketRowInput(event.currentTarget);
+});
+
 let tripStaffInitial = {};
 let tripStaffList = [];
 


### PR DESCRIPTION
## Summary
- collect focusable ticket-row inputs and expose a helper to focus the next field
- handle the Enter key so it advances to the next ticket-row input, skipping hidden and radio inputs

## Testing
- not run (not available)


------
https://chatgpt.com/codex/tasks/task_e_68e2fdc195d08322b0f73cf4288d8207