### PR TITLE
Add new permissions tab for other operations

### DIFF
--- a/utilities/database.js
+++ b/utilities/database.js
@@ -155,6 +155,10 @@ async function getTenantConnection(subdomain) {
         { id: 77, code: 'CHANGE_COMMISSION_RATE_DURING_CUT', module: 'account_cut', description: 'Hesap keserken komisyon oranını değiştirebilir', isActive: true, createdAt: '2025-09-05 16:17:02', updatedAt: '2025-08-29 17:18:42' },
         { id: 78, code: 'CHANGE_DEDUCTIONS_DURING_CUT', module: 'account_cut', description: 'Hesap keserken kesintileri değiştirebilir', isActive: true, createdAt: '2025-09-05 16:17:02', updatedAt: '2025-08-29 17:18:42' },
         { id: 79, code: 'REVERT_ACCOUNT_CUT_FOR_OTHER_BRANCH', module: 'account_cut', description: 'Başka şube adına hesap kesimini geri alabilir', isActive: true, createdAt: '2025-09-05 16:17:02', updatedAt: '2025-08-29 17:18:42' },
+        { id: 80, code: 'SUBSCRIPTION_MANAGE', module: 'other', description: 'Abonelik işlemleri yapabilir', isActive: true, createdAt: '2025-09-05 16:17:02', updatedAt: '2025-08-29 17:18:42' },
+        { id: 81, code: 'FLEET_MANAGE', module: 'other', description: 'Filo\'da işlem yapabilir', isActive: true, createdAt: '2025-09-05 16:17:02', updatedAt: '2025-08-29 17:18:42' },
+        { id: 82, code: 'ADMIN_PANEL_MANAGE', module: 'other', description: 'Yönetim panellerinde işlem yapabilir', isActive: true, createdAt: '2025-09-05 16:17:02', updatedAt: '2025-08-29 17:18:42' },
+        { id: 83, code: 'USER_PERMISSION_MANAGE', module: 'other', description: 'Kullanıcı izinlerini değiştirebilir', isActive: true, createdAt: '2025-09-05 16:17:02', updatedAt: '2025-08-29 17:18:42' },
       ];
       await models.Permission.bulkCreate(permissionsSeedData);
       console.log('Default permissions were seeded.');

--- a/views/erpscreen.pug
+++ b/views/erpscreen.pug
@@ -1457,6 +1457,8 @@ block content
                         a.nav-link(data-bs-toggle="tab" href="#satis") Satış
                     li.nav-item
                         a.nav-link(data-bs-toggle="tab" href="#hesap") Hesap Kesim
+                    li.nav-item
+                        a.nav-link(data-bs-toggle="tab" href="#diger") Diğer
                 .tab-content.mt-3.px-2(style="overflow-y: auto;height: 40vh;")
                     .tab-pane.fade.show.active#kasa
                         .form-check.mb-2
@@ -1478,6 +1480,11 @@ block content
                             input#select-all-account.form-check-input.permission-select-all(type="checkbox" data-module="account_cut")
                             label.form-check-label(for="select-all-account") Tümünü Seç
                         .permission-list(data-module="account_cut")
+                    .tab-pane.fade#diger
+                        .form-check.mb-2
+                            input#select-all-other.form-check-input.permission-select-all(type="checkbox" data-module="other")
+                            label.form-check-label(for="select-all-other") Tümünü Seç
+                        .permission-list(data-module="other")
 
     .members
         .gtr-header


### PR DESCRIPTION
## Summary
- seed new permissions for subscription, fleet, admin panel, and user permission management under the other module
- add a Diğer tab in the permission settings UI to display and manage the new other permissions

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68e3047ffc108322a7ec0defd263e33c