### PR TITLE
Disable user permission checkboxes without manage permission

### DIFF
--- a/public/scripts/erp.js
+++ b/public/scripts/erp.js
@@ -502,6 +502,12 @@ window.open = (url, ...rest) => {
 
 window.permissions = [];
 const hasPermission = code => window.permissions.includes(code);
+const canManageUserPermissions = () => hasPermission("USER_PERMISSION_MANAGE");
+
+function updatePermissionInputsAccess() {
+    const canManage = canManageUserPermissions();
+    $(".permission-select-all, .permission-checkbox").prop("disabled", !canManage);
+}
 
 function updateTakenTicketOpsVisibility($el) {
     $(".taken-ticket-op").css("display", "block");
@@ -745,6 +751,7 @@ $(function () {
     $.get('/permissions')
         .done(perms => {
             window.permissions = perms;
+            updatePermissionInputsAccess();
         })
         .fail(err => console.error(err));
 });
@@ -6469,6 +6476,7 @@ function renderPermissions(perms) {
         }
         updateSelectAllCheckbox(m);
     });
+    updatePermissionInputsAccess();
 }
 
 $(document).on('change', '.permission-select-all', function () {


### PR DESCRIPTION
## Summary
- disable permission management checkboxes when the current user lacks the USER_PERMISSION_MANAGE permission
- re-evaluate checkbox disabled state after permissions are fetched and whenever permissions are rendered

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e306726920832281b265eb12cb8a1a