### PR TITLE
Fix missing permission checkboxes in other tab

### DIFF
--- a/controllers/erpController.js
+++ b/controllers/erpController.js
@@ -4804,7 +4804,7 @@ exports.getUser = async (req, res, next) => {
     const permissions = await req.models.Permission.findAll({ attributes: ['id', 'description', 'module'] });
     const userPerms = id ? await req.models.FirmUserPermission.findAll({ where: { firmUserId: id } }) : [];
 
-    const grouped = { register: [], trip: [], sales: [], account_cut: [] };
+    const grouped = { register: [], trip: [], sales: [], account_cut: [], other: [] };
     permissions.forEach(p => {
         const allow = userPerms.some(up => up.permissionId === p.id && up.allow);
         const item = { id: p.id, description: p.description, allow };
@@ -4820,6 +4820,9 @@ exports.getUser = async (req, res, next) => {
                 break;
             case 'account_cut':
                 grouped.account_cut.push(item);
+                break;
+            case 'other':
+                grouped.other.push(item);
                 break;
         }
     });

--- a/public/scripts/erp.js
+++ b/public/scripts/erp.js
@@ -6440,7 +6440,7 @@ $(".save-branch").on("click", async e => {
 
 let editingUserId = null
 
-const permissionModules = ['register', 'trip', 'sales', 'account_cut'];
+const permissionModules = ['register', 'trip', 'sales', 'account_cut', 'other'];
 
 function updateSelectAllCheckbox(module) {
     const container = $(`.permission-list[data-module="${module}"]`);


### PR DESCRIPTION
## Summary
- include the `other` module when grouping permissions on the server
- render permission checkboxes for the Other tab by expanding the client module list

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68e309f184188322803c20e0e1ca4a1a