### PR TITLE
Use error popup for open ticket validation

### DIFF
--- a/public/scripts/erp.js
+++ b/public/scripts/erp.js
@@ -4132,6 +4132,16 @@ $(".open-ticket-next").on("click", async e => {
     const toId = $(".open-ticket-to").val()
     const count = $(".open-ticket-count").val()
 
+    if (!fromId || !toId) {
+        showError("Lütfen nereden ve nereye bilgilerini seçiniz.")
+        return
+    }
+
+    if (!count || Number(count) <= 0) {
+        showError("Lütfen bilet adedi için 0'dan büyük bir değer giriniz.")
+        return
+    }
+
     await $.ajax({
         url: "/get-ticket-row",
         type: "GET",


### PR DESCRIPTION
## Summary
- replace alert validations with the standard error popup on the open ticket sale flow

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68e30be0830083229ef820050e6ab869