### PR TITLE
Require descriptions for bus transaction popups

### DIFF
--- a/public/scripts/erp.js
+++ b/public/scripts/erp.js
@@ -4597,6 +4597,11 @@ $(".bus-transaction-button").on("click", async e => {
         return;
     }
 
+    if (!description || !description.trim()) {
+        showError("Lütfen bir açıklama giriniz.");
+        return;
+    }
+
     try {
         await $.ajax({
             url: "/post-add-bus-transaction",


### PR DESCRIPTION
## Summary
- add client-side validation to bus income and expense popups to ensure a description is provided
- display the existing error popup when the description is missing

## Testing
- not run (not applicable)


------
https://chatgpt.com/codex/tasks/task_e_68e30d5fd854832299f90d0ea65bf685