### PR TITLE
Add validation for branch popup required fields

### DIFF
--- a/public/scripts/erp.js
+++ b/public/scripts/erp.js
@@ -6393,6 +6393,21 @@ $(".save-branch").on("click", async e => {
     const defaultDeduction4 = $(".branch-deduction4").val()
     const defaultDeduction5 = $(".branch-deduction5").val()
 
+    if (!title || !String(title).trim()) {
+        showError("Şube adı zorunludur.")
+        return
+    }
+
+    if (!stop) {
+        showError("Bulunduğu durak seçilmelidir.")
+        return
+    }
+
+    if (!isMainBranch && (!mainBranch || !String(mainBranch).trim())) {
+        showError("Ana şube seçilmelidir.")
+        return
+    }
+
     await $.ajax({
         url: "/post-save-branch",
         type: "POST",


### PR DESCRIPTION
## Summary
- add client-side validation for the branch popup to ensure the title and stop are filled
- require selecting a main branch when the branch is not marked as a main branch

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68e30df86124832289259e888979ee49