### PR TITLE
Add validation for required fields in user popup

### DIFF
--- a/public/scripts/erp.js
+++ b/public/scripts/erp.js
@@ -7445,11 +7445,22 @@ $(".add-user").on("click", async e => {
 
 $(".save-user").on("click", async e => {
     const isActive = $("#isUserActive").prop("checked")
-    const name = $(".user-name").val()
-    const username = $(".user-username").val()
-    const password = $(".user-password").val()
-    const phone = $(".user-phone").val()
+    const name = ($(".user-name").val() || "").trim()
+    const username = ($(".user-username").val() || "").trim()
+    const password = ($(".user-password").val() || "").trim()
+    const phone = ($(".user-phone").val() || "").trim()
     const branchId = $(".user-branches").val()
+
+    $(".user-name").val(name)
+    $(".user-username").val(username)
+    $(".user-password").val(password)
+    $(".user-phone").val(phone)
+
+    if (!name || !username || !password || !branchId) {
+        showError("Lütfen Ad Soyad, Kullanıcı Adı, Şifre ve Şube alanlarını doldurunuz.")
+        return
+    }
+
     const permissions = $(".permission-checkbox:checked").map((_, el) => $(el).val()).get()
 
     await $.ajax({


### PR DESCRIPTION
## Summary
- trim user input values in the user popup before submission
- block saving and display the error popup when required fields are missing

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68e30e2b673883228183324c449bd044