### PR TITLE
Add validation for empty bus plans

### DIFF
--- a/public/scripts/erp.js
+++ b/public/scripts/erp.js
@@ -4691,6 +4691,11 @@ $(".bus-plans-nav").on("click", async e => {
                             const title = $(".bus-plan-title").val()
                             const description = $(".bus-plan-description").val()
 
+                            if (areAllBusPlanInputsEmpty() && (!title || !title.trim() || !description || !description.trim())) {
+                                showError("Otobüs planı boşken isim ve açıklama alanları boş bırakılamaz.")
+                                return
+                            }
+
                             let maxPassenger = 0;
                             let plan = []
                             let planBinary = ""
@@ -4834,6 +4839,18 @@ const attachBusPlanInputEvents = () => {
     })
 }
 
+const areAllBusPlanInputsEmpty = () => {
+    const inputs = $(".bus-plan-create-input")
+
+    if (!inputs.length) {
+        return true
+    }
+
+    return inputs.toArray().every(input => {
+        return !normalizeBusPlanInputValue(input.value)
+    })
+}
+
 let editingBusPlanId = null
 
 $(".add-bus-plan").on("click", async e => {
@@ -4850,6 +4867,11 @@ $(".add-bus-plan").on("click", async e => {
             $(".save-bus-plan").on("click", async e => {
                 const title = $(".bus-plan-title").val()
                 const description = $(".bus-plan-description").val()
+
+                if (areAllBusPlanInputsEmpty() && (!title || !title.trim() || !description || !description.trim())) {
+                    showError("Otobüs planı boşken isim ve açıklama alanları boş bırakılamaz.")
+                    return
+                }
 
                 let maxPassenger = 0;
                 let plan = []


### PR DESCRIPTION
## Summary
- add a helper to detect when all bus plan seat inputs are empty
- prevent saving an empty bus plan when either the title or description fields are blank and show an error popup

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e30e60e5548322bfe642d0d24e2c64