### PR TITLE
Add validation for stop popup fields

### DIFF
--- a/public/scripts/erp.js
+++ b/public/scripts/erp.js
@@ -5357,12 +5357,22 @@ $(".add-stop").on("click", e => {
 })
 
 $(".save-stop").on("click", async e => {
-    const title = $(".stop-title").val()
-    const webTitle = $(".stop-web-title").val()
-    const placeId = $(".stop-place").val()
-    const UETDS_code = $(".stop-uetds").val()
+    const title = ($(".stop-title").val() || "").trim()
+    let webTitle = ($(".stop-web-title").val() || "").trim()
+    const placeId = ($(".stop-place").val() || "").trim()
+    const UETDS_code = ($(".stop-uetds").val() || "").trim()
     const isServiceArea = $(".stop-service").is(":checked")
     const isActive = $(".stop-active").is(":checked")
+
+    if (!title || !placeId || !UETDS_code) {
+        showError("Durak adı, yer ve UETDS kodu boş bırakılamaz.")
+        return
+    }
+
+    if (!webTitle) {
+        webTitle = title
+        $(".stop-web-title").val(webTitle)
+    }
 
     await $.ajax({
         url: "/post-save-stop",


### PR DESCRIPTION
## Summary
- prevent saving stops when required fields are empty in the stops popup
- default the web title to the stop title when no web title is provided

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68e30ee5f8548322916d352894199257