### PR TITLE
Add client-side validation for trip popup required fields

### DIFF
--- a/public/scripts/erp.js
+++ b/public/scripts/erp.js
@@ -6282,6 +6282,31 @@ $(".save-trip").on("click", async e => {
     const busModelId = $(".trip-bus-model").val()
     const busId = $(".trip-bus").val()
 
+    if (!routeId) {
+        showError("Lütfen hat seçiniz.")
+        return
+    }
+
+    if (!firstDate) {
+        showError("Lütfen ilk tarihi seçiniz.")
+        return
+    }
+
+    if (!lastDate) {
+        showError("Lütfen son tarihi seçiniz.")
+        return
+    }
+
+    if (!departureTime) {
+        showError("Lütfen kalkış saatini giriniz.")
+        return
+    }
+
+    if (!busModelId) {
+        showError("Lütfen otobüs planını seçiniz.")
+        return
+    }
+
     await $.ajax({
         url: "/post-save-trip",
         type: "POST",


### PR DESCRIPTION
## Summary
- require route, first and last dates, departure time, and bus plan before saving a trip
- surface specific error messages through the existing error popup when any required field is missing

## Testing
- npm start *(fails: cannot find module ./utilities/goturDB)*

------
https://chatgpt.com/codex/tasks/task_e_68e31226748c83229a91abfa272ce7ec