### PR TITLE
Validate required fields when adding a price

### DIFF
--- a/public/scripts/erp.js
+++ b/public/scripts/erp.js
@@ -6218,6 +6218,21 @@ const savePriceAdd = async closeAfterSave => {
 
     const data = collectPriceRowData(row, { includeId: false, appendTimeSuffix: false });
 
+    if (!data.fromStopId) {
+        showError("Lütfen Nereden bilgisini seçiniz.");
+        return;
+    }
+
+    if (!data.toStopId) {
+        showError("Lütfen Nereye bilgisini seçiniz.");
+        return;
+    }
+
+    if (data.price1 == null) {
+        showError("Lütfen Fiyat1 bilgisini giriniz.");
+        return;
+    }
+
     await $.ajax({
         url: "/post-add-price",
         type: "POST",


### PR DESCRIPTION
## Summary
- validate Nereden, Nereye and Fiyat1 inputs before attempting to save a price entry
- use the existing error popup to inform users about the specific missing field

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68e31255978c832283a70936d18dcb1e