### PR TITLE
Require identity number when converting reservations to ticket sales

### DIFF
--- a/controllers/erpController.js
+++ b/controllers/erpController.js
@@ -2415,6 +2415,20 @@ exports.postTickets = async (req, res, next) => {
         const fromId = req.body.fromId;
         const toId = req.body.toId;
 
+        if (status === "completed") {
+            for (const ticket of tickets) {
+                const idNumber = typeof ticket?.idNumber === "string"
+                    ? ticket.idNumber.trim()
+                    : ticket?.idNumber !== undefined && ticket?.idNumber !== null
+                        ? String(ticket.idNumber).trim()
+                        : "";
+
+                if (!idNumber) {
+                    return res.status(400).json({ message: "Lütfen kimlik numarası giriniz." });
+                }
+            }
+        }
+
         // --- req.models.Trip.where'i dinamik kur ---
         const tripWhere = {};
         if (tripDate) tripWhere.date = tripDate;
@@ -2603,6 +2617,22 @@ exports.postCompleteTickets = async (req, res, next) => {
         const fromId = req.body.fromId;
         const toId = req.body.toId;
 
+        if (status === "completed") {
+            for (const ticket of tickets) {
+                const idNumber = typeof ticket?.idNumber === "string"
+                    ? ticket.idNumber.trim()
+                    : ticket?.idNumber !== undefined && ticket?.idNumber !== null
+                        ? String(ticket.idNumber).trim()
+                        : "";
+
+                if (!idNumber) {
+                    return res.status(400).json({ message: "Lütfen kimlik numarası giriniz." });
+                }
+
+                ticket.idNumber = idNumber;
+            }
+        }
+
         const pnr = tickets[0].pnr
         const seatNumbers = tickets.map(t => t.seatNumber)
 
@@ -2641,17 +2671,24 @@ exports.postCompleteTickets = async (req, res, next) => {
         for (let i = 0; i < foundTickets.length; i++) {
             const ticket = foundTickets[i];
             ticket.userId = req.session.firmUser.id
-            ticket.idNumber = tickets[i].idNumber
-            ticket.name = tickets[i].name
-            ticket.surname = tickets[i].surname
-            ticket.phoneNumber = tickets[i].phoneNumber
-            ticket.gender = tickets[i].gender
-            ticket.nationality = tickets[i].nationality
-            ticket.type = tickets[i].type
-            ticket.category = tickets[i].category
-            ticket.optionTime = tickets[i].optionTime
-            ticket.price = tickets[i].price
-            ticket.payment = tickets[i].payment
+            const incomingTicket = tickets[i] || {};
+            const normalizedIdNumber = typeof incomingTicket.idNumber === "string"
+                ? incomingTicket.idNumber.trim()
+                : incomingTicket.idNumber !== undefined && incomingTicket.idNumber !== null
+                    ? String(incomingTicket.idNumber).trim()
+                    : "";
+
+            ticket.idNumber = normalizedIdNumber
+            ticket.name = incomingTicket.name
+            ticket.surname = incomingTicket.surname
+            ticket.phoneNumber = incomingTicket.phoneNumber
+            ticket.gender = incomingTicket.gender
+            ticket.nationality = incomingTicket.nationality
+            ticket.type = incomingTicket.type
+            ticket.category = incomingTicket.category
+            ticket.optionTime = incomingTicket.optionTime
+            ticket.price = incomingTicket.price
+            ticket.payment = incomingTicket.payment
             ticket.status = "completed"
             ticket.createdAt = new Date()
 

--- a/public/scripts/erp.js
+++ b/public/scripts/erp.js
@@ -3007,6 +3007,80 @@ if (tripTimeAdjustInput) {
 
 let currentSeat = null;
 
+const getTrimmedValue = value => {
+    if (value === undefined || value === null) {
+        return "";
+    }
+
+    if (typeof value === "string") {
+        return value.trim();
+    }
+
+    return String(value).trim();
+};
+
+const validateTicketForm = action => {
+    if (!action) {
+        return true;
+    }
+
+    const $rows = $(".ticket-row");
+    const phoneValue = getTrimmedValue($(".ticket-rows .phone input").val());
+    const requiresPassengerInfo = action === "reservation" || action === "sell" || action === "complete";
+    const requiresIdentityNumber = action === "sell" || action === "complete";
+
+    if (requiresPassengerInfo && !phoneValue) {
+        showError("Lütfen telefon numarası giriniz.");
+        return false;
+    }
+
+    if (requiresPassengerInfo) {
+        for (let i = 0; i < $rows.length; i++) {
+            const $row = $rows.eq(i);
+
+            const nameValue = getTrimmedValue($row.find(".name input").val());
+            if (!nameValue) {
+                showError("Lütfen isim giriniz.");
+                return false;
+            }
+
+            const surnameValue = getTrimmedValue($row.find(".surname input").val());
+            if (!surnameValue) {
+                showError("Lütfen soyisim giriniz.");
+                return false;
+            }
+
+            if (requiresIdentityNumber) {
+                const idNumberValue = getTrimmedValue($row.find(".identity input").val());
+                if (!idNumberValue) {
+                    showError("Lütfen kimlik numarası giriniz.");
+                    return false;
+                }
+            }
+        }
+    }
+
+    if (action === "sell") {
+        const $reservationWrapper = $(".ticket-rows .reservation-expire");
+
+        if ($reservationWrapper.length) {
+            const $dateInput = $reservationWrapper.find("input.date");
+            if ($dateInput.length && !getTrimmedValue($dateInput.val())) {
+                showError("Lütfen rezervasyon opsiyon tarihini giriniz.");
+                return false;
+            }
+
+            const $timeInput = $reservationWrapper.find("input.time");
+            if ($timeInput.length && !getTrimmedValue($timeInput.val())) {
+                showError("Lütfen rezervasyon opsiyon saatini giriniz.");
+                return false;
+            }
+        }
+    }
+
+    return true;
+};
+
 // Boş koltuk menüsü alt menüsünü açar
 $(".ticket-op").on("click", e => {
     e.stopPropagation();
@@ -3050,7 +3124,13 @@ $("#currentStop").on("change", async (e) => {
 
 // Bilet kesim ekranındaki onaylama tuşu
 $(".ticket-button-action").on("click", async e => {
-    if (e.currentTarget.dataset.action == "sell") {
+    const action = e.currentTarget.dataset.action;
+
+    if ((action === "reservation" || action === "sell") && !validateTicketForm(action)) {
+        return;
+    }
+
+    if (action == "sell") {
         const firstTicket = $(".ticket-row").first();
         const price = Number(firstTicket.find(".price").find("input").val());
         const span = firstTicket.find(".price").find("span.customer-point");
@@ -3116,7 +3196,7 @@ $(".ticket-button-action").on("click", async e => {
             });
         }
     }
-    else if (e.currentTarget.dataset.action == "complete") {
+    else if (action == "complete") {
         let tickets = []
         const takeOnValue = ($(".ticket-rows").find(".take-on select").val() || "").toString().trim();
         const takeOffValue = ($(".ticket-rows").find(".take-off select").val() || "").toString().trim();
@@ -3163,7 +3243,7 @@ $(".ticket-button-action").on("click", async e => {
         });
 
     }
-    else if (e.currentTarget.dataset.action == "sell_open") {
+    else if (action == "sell_open") {
         let tickets = []
         const fromId = $(".open-ticket-from").val()
         const toId = $(".open-ticket-to").val()
@@ -3209,7 +3289,7 @@ $(".ticket-button-action").on("click", async e => {
         });
 
     }
-    else if (e.currentTarget.dataset.action == "edit") {
+    else if (action == "edit") {
 
         const ticket = $(".ticket-row")
 
@@ -3252,7 +3332,7 @@ $(".ticket-button-action").on("click", async e => {
             }
         });
     }
-    else if (e.currentTarget.dataset.action == "reservation") {
+    else if (action == "reservation") {
         let tickets = []
         const takeOnValue = ($(".ticket-rows").find(".take-on select").val() || "").toString().trim();
         const takeOffValue = ($(".ticket-rows").find(".take-off select").val() || "").toString().trim();
@@ -3300,7 +3380,7 @@ $(".ticket-button-action").on("click", async e => {
         });
 
     }
-    else if (e.currentTarget.dataset.action == "cancel") {
+    else if (action == "cancel") {
 
         if (selectedTakenSeats.length > 0) {
             let json = JSON.stringify(selectedTakenSeats)
@@ -3323,7 +3403,7 @@ $(".ticket-button-action").on("click", async e => {
         }
 
     }
-    else if (e.currentTarget.dataset.action == "refund") {
+    else if (action == "refund") {
 
         if (selectedTakenSeats.length > 0) {
             let json = JSON.stringify(selectedTakenSeats)
@@ -3346,7 +3426,7 @@ $(".ticket-button-action").on("click", async e => {
         }
 
     }
-    else if (e.currentTarget.dataset.action == "open") {
+    else if (action == "open") {
 
         if (selectedTakenSeats.length > 0) {
             let json = JSON.stringify(selectedTakenSeats)


### PR DESCRIPTION
## Summary
- enforce the same passenger validation for reservation-to-sale conversions on the ticket form, including mandatory ID numbers
- ensure backend sale completion rejects tickets missing identity numbers while trimming provided values

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68e39c1c60948322a0dd9561b3476ba8