### PR TITLE
Stop creating customers during reservations

### DIFF
--- a/controllers/erpController.js
+++ b/controllers/erpController.js
@@ -2582,6 +2582,8 @@ exports.postTickets = async (req, res, next) => {
 
         const takeOnCache = await prepareTakeValueCache(req.models.TakeOn);
         const takeOffCache = await prepareTakeValueCache(req.models.TakeOff);
+        const isReservationStatus = status === "reservation";
+
         // --- Tüm biletleri sırayla kaydet ---
         for (let i = 0; i < tickets.length; i++) {
             const t = tickets[i]
@@ -2635,16 +2637,18 @@ exports.postTickets = async (req, res, next) => {
             }
 
             if (!existingCustomer) {
-                await req.models.Customer.create({
-                    idNumber: t.idNumber || null,
-                    name: nameUp || null,
-                    surname: surnameUp || null,
-                    phoneNumber: t.phoneNumber || null,
-                    gender: t.gender || null,
-                    nationality: t.nationality || null,
-                    customerType: t.type || null,
-                    customerCategory: t.category || null
-                });
+                if (!isReservationStatus) {
+                    await req.models.Customer.create({
+                        idNumber: t.idNumber || null,
+                        name: nameUp || null,
+                        surname: surnameUp || null,
+                        phoneNumber: t.phoneNumber || null,
+                        gender: t.gender || null,
+                        nationality: t.nationality || null,
+                        customerType: t.type || null,
+                        customerCategory: t.category || null
+                    });
+                }
             }
             else {
                 ticket.customerId = existingCustomer.id
@@ -2871,6 +2875,8 @@ exports.postSellOpenTickets = async (req, res, next) => {
         const takeOnCache = await prepareTakeValueCache(req.models.TakeOn);
         const takeOffCache = await prepareTakeValueCache(req.models.TakeOff);
 
+        const isReservationStatus = status === "reservation";
+
         for (const t of tickets) {
             const takeOnTitle = await ensureTakeValue(takeOnCache, t.takeOn);
             const takeOffTitle = await ensureTakeValue(takeOffCache, t.takeOff);
@@ -2913,16 +2919,18 @@ exports.postSellOpenTickets = async (req, res, next) => {
             }
 
             if (!existingCustomer) {
-                await req.models.Customer.create({
-                    idNumber: t.idNumber || null,
-                    name: nameUp || null,
-                    surname: surnameUp || null,
-                    phoneNumber: t.phoneNumber || null,
-                    gender: t.gender || null,
-                    nationality: t.nationality || null,
-                    customerType: t.type || null,
-                    customerCategory: t.category || null
-                });
+                if (!isReservationStatus) {
+                    await req.models.Customer.create({
+                        idNumber: t.idNumber || null,
+                        name: nameUp || null,
+                        surname: surnameUp || null,
+                        phoneNumber: t.phoneNumber || null,
+                        gender: t.gender || null,
+                        nationality: t.nationality || null,
+                        customerType: t.type || null,
+                        customerCategory: t.category || null
+                    });
+                }
             }
 
 


### PR DESCRIPTION
## Summary
- prevent customer records from being created when tickets are saved as reservations
- reuse the same guard in open ticket sales so customer creation only happens for non-reservation statuses

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e59d6c8a808322a508252c16e2a3dc