### PR TITLE
Refactor Gotur DB initialization and startup sync

### DIFF
--- a/app.js
+++ b/app.js
@@ -8,9 +8,11 @@ var logger = require("morgan");
 var usersRouter = require("./routes/users");
 var erpRouter = require("./routes/erp");
 
-const { goturDB, initGoturModels } = require("./utilities/goturDB"); // ortak kullanıcı & session DB
+const { goturDB, initGoturModels } = require("./utilities/goturDb"); // ortak kullanıcı & session DB
 const SequelizeStore = require("connect-session-sequelize")(session.Store);
 const tenantMiddleware = require("./middlewares/tenantMiddleware");
+
+const commonModels = initGoturModels();
 
 // session store (gotur DB üzerinde)
 var store = new SequelizeStore({
@@ -51,7 +53,7 @@ app.use(tenantMiddleware);
 
 // ortak modelleri (gotur DB) request içine ekle
 app.use((req, res, next) => {
-  req.commonModels = initGoturModels(); // Place vs.
+  req.commonModels = commonModels; // Place vs.
   res.locals.firmUser = req.session.firmUser;
   res.locals.permissions = req.session.permissions || [];
   next();

--- a/bin/www
+++ b/bin/www
@@ -7,6 +7,7 @@
 var app = require('../app');
 var debug = require('debug')('gotur-vip:server');
 var http = require('http');
+const { getGoturSyncPromise } = require('../utilities/goturDb');
 
 /**
  * Get port from environment and store in Express.
@@ -22,15 +23,27 @@ app.set('port', port);
 var server = http.createServer(app);
 
 var reservationCleanupJob = require('./reservationCleanupJob');
-reservationCleanupJob.start();
 
-/**
- * Listen on provided port, on all network interfaces.
- */
+startServer();
 
-server.listen(port);
-server.on('error', onError);
-server.on('listening', onListening);
+async function startServer() {
+  try {
+    await getGoturSyncPromise();
+  } catch (error) {
+    console.error('Gotur DB senkronizasyonu başarısız oldu:', error);
+    process.exit(1);
+  }
+
+  reservationCleanupJob.start();
+
+  /**
+   * Listen on provided port, on all network interfaces.
+   */
+
+  server.listen(port);
+  server.on('error', onError);
+  server.on('listening', onListening);
+}
 
 /**
  * Normalize a port into a number, string, or false.

--- a/middlewares/tenantMiddleware.js
+++ b/middlewares/tenantMiddleware.js
@@ -1,6 +1,16 @@
 const { getTenantConnection } = require("../utilities/database");
-const { initGoturModels } = require("../utilities/goturDB");
+const { initGoturModels } = require("../utilities/goturDb");
 const { DEFAULT_TENANT_KEY, resolveTenantKey } = require("../utilities/tenantConfig");
+
+let cachedCommonModels;
+
+function getCommonModels() {
+    if (!cachedCommonModels) {
+        cachedCommonModels = initGoturModels();
+    }
+
+    return cachedCommonModels;
+}
 
 module.exports = async (req, res, next) => {
     try {
@@ -21,7 +31,7 @@ module.exports = async (req, res, next) => {
         const { sequelize, models } = await getTenantConnection(subdomain);
 
         // ortak DB (gotur)
-        const commonModels = initGoturModels();
+        const commonModels = getCommonModels();
 
         req.db = sequelize;
         req.models = models;             // tenant modelleri

--- a/utilities/goturDb.js
+++ b/utilities/goturDb.js
@@ -30,11 +30,28 @@ const goturDB = new Sequelize(
     sanitizedOptions
 );
 
+const goturModels = Object.freeze({
+    Firm: FirmFactory(goturDB),
+    Place: PlaceFactory(goturDB),
+});
+
+let goturSyncPromise;
+
 function initGoturModels() {
-    const Firm = FirmFactory(goturDB); // 👈 mevcut modelini kullan
-    const Place = PlaceFactory(goturDB); // 👈 mevcut modelini kullan
-    goturDB.sync({ alter: true });
-    return { Place, Firm };
+    return goturModels;
 }
 
-module.exports = { goturDB, initGoturModels };
+function getGoturSyncPromise() {
+    if (!goturSyncPromise) {
+        goturSyncPromise = goturDB.sync({ alter: true }).catch((error) => {
+            goturSyncPromise = null;
+            throw error;
+        });
+    }
+
+    return goturSyncPromise;
+}
+
+getGoturSyncPromise();
+
+module.exports = { goturDB, initGoturModels, getGoturSyncPromise };


### PR DESCRIPTION
## Summary
- define the Gotur Sequelize models once during module load and expose cached references
- provide a reusable sync promise and await it during server startup with failure handling
- reuse cached Gotur models in the app setup and tenant middleware instead of recreating per request

## Testing
- Not run (database connection not available in test environment)


------
https://chatgpt.com/codex/tasks/task_e_68e5a2b8a94c8322a7887232188371c6