### PR TITLE
Enhance ERP main view responsiveness

### DIFF
--- a/public/stylesheets/erpscreen.css
+++ b/public/stylesheets/erpscreen.css
@@ -2,7 +2,8 @@ html,
 body {
     height: 100%;
     width: 100%;
-    overflow: hidden;
+    overflow-x: hidden;
+    overflow-y: hidden;
 }
 
 body {
@@ -159,6 +160,27 @@ body {
     box-shadow: 0 0.5rem 1rem rgb(0 0 0 / 20%);
     background-color: white;
     user-select: none;
+}
+
+.erp-main-layout {
+    height: 89vh;
+}
+
+.trip-branding {
+    width: 100%;
+    min-height: 10vh;
+    display: flex;
+    align-items: center;
+    justify-content: space-evenly;
+    background-color: white;
+    border-radius: 5px;
+    padding: 0.75rem;
+    gap: 1rem;
+}
+
+.trip-branding .firm-logo {
+    max-width: 160px;
+    height: auto;
 }
 
 .passenger-table table {
@@ -1599,6 +1621,262 @@ div.ticket-cancel-refund-open-close {
     gap: 1rem;
 }
 
+@media (max-width: 1200px) {
+    html,
+    body {
+        overflow-y: auto;
+    }
+
+    .ticket-search-pop-up,
+    .open-ticket-sale,
+    .add-transaction,
+    .bus-transaction,
+    .add-announcement,
+    .transaction-transfer,
+    .payment-request,
+    .payment-send,
+    .pending-payments,
+    .pending-collections,
+    .other-register,
+    .register,
+    .bus,
+    .route,
+    .stops,
+    .staff,
+    .prices,
+    .trip,
+    .branch,
+    .users,
+    .customers,
+    .members,
+    .member-info,
+    .price-add-popup,
+    .ticket-info-pop-up,
+    .account-cut-deductions-popup,
+    .account-cut-popup,
+    .trip-revenue-pop-up,
+    .trip-staff-pop-up,
+    .trip-cargo-pop-up,
+    .trip-cargo-list-pop-up,
+    .trip-stop-restriction-pop-up,
+    .ticket-cancel-refund-open,
+    .moving,
+    .add-trip-note,
+    .reports-popup,
+    .report-popup,
+    .error-popup,
+    .customer-blacklist-pop-up,
+    .trip-time-adjust-pop-up,
+    .user-profile-popup,
+    .change-password-popup,
+    .bus-plans {
+        width: 95vw;
+        max-width: 95vw;
+        max-height: 90vh;
+        overflow-y: auto;
+    }
+
+    .register-data-input {
+        width: 48% !important;
+    }
+
+    .ticket-search-pop-up .inputs {
+        gap: .75rem;
+    }
+
+    .ticket-search-pop-up .inputs div {
+        width: calc(50% - .5rem) !important;
+        flex: 1 1 calc(50% - .5rem);
+    }
+
+    .pending-payments,
+    .pending-collections,
+    .bus-transaction {
+        max-width: 680px;
+    }
+
+    .erp-main-layout {
+        height: auto;
+        min-height: 89vh;
+        row-gap: 1.5rem;
+    }
+
+    .erp-main-layout > [class*="col-"] {
+        height: auto !important;
+    }
+
+    .passenger-table {
+        height: auto;
+        max-height: 60vh;
+    }
+
+    .notes-stops {
+        flex-direction: column;
+        gap: 1rem;
+        height: auto;
+    }
+
+    .notes-stops > .w-50 {
+        width: 100% !important;
+    }
+
+    .trip-notes,
+    .stops-times {
+        max-height: 30vh;
+    }
+
+    .right-panel {
+        align-items: stretch;
+        gap: 1.5rem;
+    }
+
+    .tripRows {
+        height: auto;
+        max-height: 60vh;
+    }
+
+    .trip-branding {
+        min-height: 0;
+        justify-content: space-between;
+    }
+}
+
+@media (max-width: 768px) {
+    nav.navbar {
+        height: auto !important;
+        padding: .5rem 1rem;
+    }
+
+    nav.navbar .navbar-brand img {
+        height: 24px;
+        width: auto;
+    }
+
+    .ticket-search-pop-up,
+    .open-ticket-sale,
+    .add-transaction,
+    .bus-transaction,
+    .add-announcement,
+    .transaction-transfer,
+    .payment-request,
+    .payment-send,
+    .pending-payments,
+    .pending-collections,
+    .other-register,
+    .register,
+    .bus,
+    .route,
+    .stops,
+    .staff,
+    .prices,
+    .trip,
+    .branch,
+    .users,
+    .customers,
+    .members,
+    .member-info,
+    .price-add-popup,
+    .ticket-info-pop-up,
+    .account-cut-deductions-popup,
+    .account-cut-popup,
+    .trip-revenue-pop-up,
+    .trip-staff-pop-up,
+    .trip-cargo-pop-up,
+    .trip-cargo-list-pop-up,
+    .trip-stop-restriction-pop-up,
+    .ticket-cancel-refund-open,
+    .moving,
+    .add-trip-note,
+    .reports-popup,
+    .report-popup,
+    .error-popup,
+    .customer-blacklist-pop-up,
+    .trip-time-adjust-pop-up,
+    .user-profile-popup,
+    .change-password-popup,
+    .bus-plans {
+        width: calc(100vw - 2rem);
+        max-width: calc(100vw - 2rem);
+        max-height: 90vh;
+        overflow-y: auto;
+    }
+
+    .ticket-search-pop-up .inputs {
+        flex-direction: column;
+    }
+
+    .ticket-search-pop-up .inputs div,
+    .register-data-input {
+        width: 100% !important;
+    }
+
+    .register .d-flex,
+    .other-register .d-flex,
+    .route .d-flex,
+    .stops .d-flex,
+    .staff .d-flex,
+    .prices .d-flex,
+    .trip .d-flex,
+    .branch .d-flex,
+    .users .d-flex,
+    .customers .d-flex,
+    .members .d-flex,
+    .member-info .d-flex {
+        flex-direction: column !important;
+        gap: 1rem;
+    }
+
+    .bus-settings,
+    .bus-info,
+    .route-settings,
+    .route-info,
+    .trip-settings,
+    .trip-info,
+    .branch-settings,
+    .branch-info,
+    .user-settings,
+    .user-info,
+    .member-info-left,
+    .member-info-middle,
+    .member-info-right {
+        width: 100% !important;
+        border-right: none;
+    }
+
+    .bus-settings,
+    .bus-info,
+    .route-settings,
+    .route-info,
+    .trip-settings,
+    .trip-info,
+    .branch-settings,
+    .branch-info,
+    .user-settings,
+    .user-info,
+    .member-info-left,
+    .member-info-middle {
+        border-bottom: 1px solid #dee2e6;
+        padding-bottom: 1rem;
+    }
+
+    .prices,
+    .trip,
+    .bus,
+    .route,
+    .stops,
+    .staff,
+    .member-info,
+    .ticket-info-pop-up,
+    .price-add-popup,
+    .member-info-right {
+        min-width: auto;
+    }
+
+    .member-ticket-list {
+        max-height: 45vh;
+    }
+}
+
 .ticket-row.m {
     background-color: #21639650;
 }
@@ -2172,6 +2450,78 @@ div.ticket-cancel-refund-open-close {
     font-size: .8125rem;
     padding: .5rem 0;
     text-align: center;
+}
+
+@media (max-width: 768px) {
+    .erp-main-layout {
+        row-gap: 2rem;
+    }
+
+    .passenger-table {
+        max-height: 50vh;
+    }
+
+    .trip-notes,
+    .stops-times {
+        max-height: 40vh;
+    }
+
+    .busPlan {
+        width: 100%;
+        overflow-x: auto;
+    }
+
+    .seats {
+        padding: 0.75rem;
+    }
+
+    .seat {
+        width: 5rem;
+        height: 3rem;
+    }
+
+    .seat .seat-number {
+        font-size: 1.35rem;
+    }
+
+    .right-panel {
+        align-items: stretch;
+    }
+
+    .trip-branding {
+        flex-direction: column;
+        align-items: center;
+        text-align: center;
+        gap: 1rem;
+    }
+}
+
+@media (max-width: 576px) {
+    .seat {
+        width: 4rem;
+        height: 2.75rem;
+    }
+
+    .seat .seat-number {
+        font-size: 1.1rem;
+    }
+
+    .passenger-table {
+        max-height: 45vh;
+    }
+
+    .tripRows {
+        max-height: 45vh;
+    }
+
+    .trip-branding {
+        gap: 0.75rem;
+        padding: 0.75rem;
+    }
+
+    .trip-branding .firm-logo {
+        max-width: 120px;
+    }
 }
 
 .is-main-branch-group{

--- a/views/erplayout.pug
+++ b/views/erplayout.pug
@@ -2,6 +2,7 @@ doctype html
 html
   head
     title= title
+    meta(name="viewport" content="width=device-width, initial-scale=1")
     link(rel="icon" type="image/png" sizes="32x32" href="/images/favicon-32x32.png")
     link(rel="icon" type="image/png" sizes="16x16" href="/images/favicon-16x16.png")
     link(rel="apple-touch-icon" sizes="180x180" href="/images/apple-touch-icon.png")

--- a/views/erpscreen.pug
+++ b/views/erpscreen.pug
@@ -1656,8 +1656,8 @@ block content
             button.btn.btn-secondary.customer-blacklist-close KAPAT
             button.btn.btn-primary.customer-blacklist-add EKLE
 
-    .row(style="height: 89vh;")
-        .col-4.h-100
+    .row.erp-main-layout
+        .col-12.col-lg-4.h-100.mb-3.mb-lg-0
             .passenger-table.mb-3
             .notes-stops
                 .bg-white.h-100.p-2.w-50
@@ -1672,10 +1672,10 @@ block content
 
             .ticker
                 p
-        .col-5.d-flex.flex-column.align-items-center.px-3.gap-2.h-100
+        .col-12.col-lg-5.d-flex.flex-column.align-items-center.px-3.gap-2.h-100.mb-3.mb-lg-0
             .busPlan
 
-        .col-3.h-100.right-panel
+        .col-12.col-lg-3.h-100.right-panel.mt-3.mt-lg-0
             input#calendar(type="hidden" name="")
             select#currentStop.form-select.form-select-sm(value=branchStopId data-searchable-select data-search-placeholder="Durak ara")
                 each s in stops
@@ -1683,7 +1683,7 @@ block content
                         option(value=s.id selected) #{s.title}
                     else
                         option(value=s.id) #{s.title}
-            .tripRows 
-            div(style="width: 100%;height: 10vh;display:flex;align-items: center;justify-content: space-evenly;background-color: white;border-radius: 5px;")
+            .tripRows
+            .trip-branding
                 img.firm-logo(src="/images/anafartalar.png")
                 #clock


### PR DESCRIPTION
## Summary
- convert the ERP screen layout to responsive Bootstrap column classes and add a reusable trip branding container
- add responsive CSS for the passenger list, notes, bus plan and right panel so they resize and scroll cleanly on tablets and phones

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68e5b6b9923c8322aecdc41adbb5f408