### PR TITLE
Add dotenv-based environment configuration

### DIFF
--- a/.env
+++ b/.env
@@ -1,0 +1,25 @@
+# Server configuration
+PORT=4000
+SESSION_SECRET=anadolutat
+
+# Tenant database connection
+DB_USERNAME=root
+DB_PASSWORD=anadolutat1071
+DB_HOST=localhost
+DB_PORT=3306
+DB_DIALECT=mysql
+DB_TIMEZONE=+03:00
+DEFAULT_USER_PASSWORD=anadolutat1071
+
+# Common Gotur database connection
+GOTUR_DB_NAME=gotur
+GOTUR_DB_USERNAME=root
+GOTUR_DB_PASSWORD=anadolutat1071
+GOTUR_DB_HOST=localhost
+GOTUR_DB_PORT=3306
+GOTUR_DB_DIALECT=mysql
+GOTUR_DB_TIMEZONE=+03:00
+
+# Reservation cleanup job
+RESERVATION_JOB_TENANT_KEY=
+RESERVATION_JOB_TENANT_KEYS=

--- a/.gitignore
+++ b/.gitignore
@@ -10,7 +10,7 @@ yarn-error.log*
 pnpm-debug.log*
 
 # Environment files
-.env
+!.env
 .env.test
 .env.production
 .env.local

--- a/README.md
+++ b/README.md
@@ -1,12 +1,70 @@
 # Gotur VIP
 
-This project now includes a background job that cancels expired ticket reservations.
+Gotur VIP is a multi-tenant reservation platform built on Express and Sequelize.
+It serves the public web app together with a background worker that keeps tenant
+reservations up to date.
 
-## Reservation Cleanup Job
+## Quick start
 
-* Runs every minute and marks expired `reservation` tickets as `canceled`.
-* Implemented in [`bin/reservationCleanupJob.js`](bin/reservationCleanupJob.js).
-* The job starts automatically when the server boots via `bin/www`.
+1. Install dependencies:
+   ```bash
+   npm install
+   ```
+2. Duplicate the provided `.env` and adjust the credentials for your
+   infrastructure if needed.
+3. Start the HTTP server:
+   ```bash
+   npm run dev
+   ```
+4. Access the application from `http://localhost:4000`.
+
+## Environment configuration
+
+The application reads its configuration from the `.env` file at the project
+root. The default values are suitable for local development, but you should
+change them before deploying to any shared environment.
+
+| Variable | Description |
+| --- | --- |
+| `PORT` | Port number Express listens on. |
+| `SESSION_SECRET` | Secret used to sign Express session cookies. |
+| `DB_*` | Connection settings for tenant specific databases. |
+| `DEFAULT_USER_PASSWORD` | Password for the seed tenant user that is created when a new tenant database is provisioned. |
+| `GOTUR_DB_*` | Connection settings for the common Gotur database that stores session and shared models. |
+| `RESERVATION_JOB_TENANT_KEYS` | A comma separated list of tenant identifiers processed by the reservation cleanup worker. |
+
+All configuration keys are optional—if a value is missing in the `.env` file the
+code falls back to the safe default that was used previously. When running in
+production, make sure the secrets are rotated and not left to their default
+values.
+
+## Tenant lifecycle tasks
+
+Most application features depend on tenant specific databases. When a new
+subdomain is requested for the first time the application will automatically:
+
+- connect to the tenant database defined by `DB_*` using the subdomain as the
+  database name,
+- run `sequelize.sync({ alter: true })` to ensure tables are created,
+- seed a default `FirmUser` with the username `GOTUR` and the password defined
+  by `DEFAULT_USER_PASSWORD`,
+- populate the `Permission` table if it is empty.
+
+You can verify the connection by visiting a page under the tenant subdomain or
+by requiring `getTenantConnection` from `utilities/database.js` inside a script
+that runs in the project context.
+
+## Reservation cleanup job
+
+The reservation cleanup job cancels expired ticket reservations automatically.
+It is implemented in [`bin/reservationCleanupJob.js`](bin/reservationCleanupJob.js)
+and starts together with the HTTP server via `bin/www`.
+
+### Scheduling options
+
+Set `RESERVATION_JOB_TENANT_KEYS` in the `.env` file to a comma-separated list
+of tenants that should be processed. If left empty the job will run only for
+subdomains that establish a session during runtime.
 
 ### Manual control
 
@@ -16,4 +74,6 @@ job.stop(); // stops the scheduler
 job.start(); // restarts it
 ```
 
-Add notification hooks inside the job if a user/branch alert system is available.
+You can extend the job handler with any notification logic that your
+infrastructure requires (for example, sending alerts when reservations are
+canceled).

--- a/app.js
+++ b/app.js
@@ -1,3 +1,5 @@
+require("dotenv").config();
+
 var createError = require("http-errors");
 var express = require("express");
 var path = require("path");
@@ -24,6 +26,8 @@ store.sync();
 
 var app = express();
 
+const sessionSecret = process.env.SESSION_SECRET || "anadolutat";
+
 // view engine setup
 app.set("views", path.join(__dirname, "views"));
 app.set("view engine", "pug");
@@ -38,7 +42,7 @@ app.use(express.static(path.join(__dirname, "node_modules")));
 // session middleware
 app.use(
   session({
-    secret: "anadolutat",
+    secret: sessionSecret,
     resave: false,
     saveUninitialized: false,
     store: store,

--- a/package-lock.json
+++ b/package-lock.json
@@ -14,6 +14,7 @@
         "connect-session-sequelize": "^8.0.2",
         "cookie-parser": "~1.4.4",
         "debug": "~2.6.9",
+        "dotenv": "^16.4.5",
         "express": "~4.16.1",
         "express-session": "^1.18.2",
         "flatpickr": "^4.6.13",

--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
     "connect-session-sequelize": "^8.0.2",
     "cookie-parser": "~1.4.4",
     "debug": "~2.6.9",
+    "dotenv": "^16.4.5",
     "express": "~4.16.1",
     "express-session": "^1.18.2",
     "flatpickr": "^4.6.13",

--- a/utilities/database.js
+++ b/utilities/database.js
@@ -5,6 +5,8 @@ const connections = {};
 
 const DB_USERNAME = process.env.DB_USERNAME || "root";
 const DB_PASSWORD = process.env.DB_PASSWORD || "anadolutat1071";
+const DEFAULT_USER_PASSWORD =
+  process.env.DEFAULT_USER_PASSWORD || "anadolutat1071";
 
 function buildConnectionOptions() {
   const options = {
@@ -63,7 +65,7 @@ async function getTenantConnection(subdomain) {
   if (models.FirmUser) {
     const count = await models.FirmUser.count();
     if (count === 0) {
-      const hashedPassword = await bcrypt.hash("anadolutat1071", 10);
+      const hashedPassword = await bcrypt.hash(DEFAULT_USER_PASSWORD, 10);
       await models.FirmUser.create({
         branchId: 0,
         username: "GOTUR",


### PR DESCRIPTION
## Summary
- load application configuration from a tracked `.env` file using dotenv
- move session and database secrets to environment variables and document the setup
- expose the `.env` file in version control and add the dotenv runtime dependency
- expand the README with setup steps and guidance for tenant lifecycle tasks and the reservation cleanup job

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68e5c17c3e2883229eb71636469d1d7d