### PR TITLE
Seed default web branches and users

### DIFF
--- a/models/branchModel.js
+++ b/models/branchModel.js
@@ -13,7 +13,7 @@ module.exports = (sequelize) => {
     },
     stopId: {
       type: DataTypes.BIGINT,
-      allowNull: false,
+      allowNull: true,
     },
     isActive: {
       type: DataTypes.BOOLEAN,

--- a/utilities/database.js
+++ b/utilities/database.js
@@ -61,19 +61,69 @@ async function getTenantConnection(subdomain) {
   // tabloları oluştur
   await sequelize.sync({ alter: true });
 
-  // default kullanıcı ekle
+  // default kullanıcı ve şubeleri ekle
   if (models.FirmUser) {
     const count = await models.FirmUser.count();
     if (count === 0) {
+      let webBranchId = null;
+      let goturComBranchId = null;
+
+      if (models.Branch) {
+        const branchSeeds = [
+          { title: "WEB", assign: (branch) => (webBranchId = branch.id) },
+          { title: "götür.com", assign: (branch) => (goturComBranchId = branch.id) },
+        ];
+
+        for (const seed of branchSeeds) {
+          const [branch] = await models.Branch.findOrCreate({
+            where: { title: seed.title },
+            defaults: {
+              stopId: null,
+              isActive: true,
+              isMainBranch: false,
+            },
+          });
+
+          seed.assign(branch);
+        }
+      }
+
       const hashedPassword = await bcrypt.hash(DEFAULT_USER_PASSWORD, 10);
-      await models.FirmUser.create({
-        branchId: 0,
-        username: "GOTUR",
-        password: hashedPassword,
-        name: "Götür Sistem Kullanıcısı",
-        phoneNumber: "0850 840 1915",
-      });
-      console.log(`[${tenantKey}] için default kullanıcı eklendi.`);
+
+      const defaultUsers = [
+        {
+          branchId: goturComBranchId,
+          username: "GOTUR",
+          name: "Götür Sistem Kullanıcısı",
+          phoneNumber: "0850 840 1915",
+        },
+        {
+          branchId: webBranchId,
+          username: "WEB",
+          name: "Web",
+        },
+        {
+          branchId: goturComBranchId,
+          username: "gotur.com",
+          name: "götür.com",
+        },
+      ];
+
+      for (const user of defaultUsers) {
+        if (user.branchId == null) {
+          continue;
+        }
+
+        await models.FirmUser.create({
+          branchId: user.branchId,
+          username: user.username,
+          password: hashedPassword,
+          name: user.name,
+          phoneNumber: user.phoneNumber ?? null,
+        });
+      }
+
+      console.log(`[${tenantKey}] için default kullanıcılar eklendi.`);
     }
   }
 


### PR DESCRIPTION
## Summary
- allow system branches to omit a stop by permitting null `stopId`
- seed WEB and götür.com branches and related default users when initializing an empty tenant

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68e5c7c842388322839e61e9c47e285b