### PR TITLE
Grant all permissions to GOTUR system user

### DIFF
--- a/models/branchModel.js
+++ b/models/branchModel.js
@@ -13,7 +13,7 @@ module.exports = (sequelize) => {
     },
     stopId: {
       type: DataTypes.BIGINT,
-      allowNull: false,
+      allowNull: true,
     },
     isActive: {
       type: DataTypes.BOOLEAN,


### PR DESCRIPTION
## Summary
- allow system branches to omit a stop by permitting null `stopId`
- seed WEB and götür.com branches and related default users when initializing an empty tenant
- grant the Götür system user every available permission during tenant initialization

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68e5c7c842388322839e61e9c47e285b