### PR TITLE
Scope ERP sessions per tenant

### DIFF
--- a/app.js
+++ b/app.js
@@ -13,6 +13,7 @@ var erpRouter = require("./routes/erp");
 const { goturDB, initGoturModels } = require("./utilities/goturDb"); // ortak kullanıcı & session DB
 const SequelizeStore = require("connect-session-sequelize")(session.Store);
 const tenantMiddleware = require("./middlewares/tenantMiddleware");
+const tenantSessionMiddleware = require("./middlewares/tenantSessionMiddleware");
 
 const commonModels = initGoturModels();
 
@@ -55,11 +56,12 @@ app.use(
 // tenant middleware (subdomain -> tenant DB)
 app.use(tenantMiddleware);
 
+// tenant bazlı session bilgisi
+app.use(tenantSessionMiddleware);
+
 // ortak modelleri (gotur DB) request içine ekle
 app.use((req, res, next) => {
   req.commonModels = commonModels; // Place vs.
-  res.locals.firmUser = req.session.firmUser;
-  res.locals.permissions = req.session.permissions || [];
   next();
 });
 

--- a/middlewares/authentication.js
+++ b/middlewares/authentication.js
@@ -1,7 +1,12 @@
 const session = require("express-session")
 
 module.exports = (req, res, next) => {
-    if (req.session.isAuthenticated) {
+    const tenantKey = req.tenantKey;
+    const tenantSession = tenantKey && req.session && req.session.tenants
+        ? req.session.tenants[tenantKey]
+        : null;
+
+    if (tenantSession?.isAuthenticated) {
         return next();
     }
     req.session.redirectTo = req.originalUrl;

--- a/middlewares/tenantSessionMiddleware.js
+++ b/middlewares/tenantSessionMiddleware.js
@@ -1,0 +1,82 @@
+const DEFAULT_ARRAY = Object.freeze([]);
+
+function ensureTenantsContainer(session) {
+    if (!session.tenants || typeof session.tenants !== "object") {
+        session.tenants = {};
+    }
+    return session.tenants;
+}
+
+function ensureTenantEntry(session, tenantKey) {
+    const tenants = ensureTenantsContainer(session);
+
+    if (!tenants[tenantKey]) {
+        tenants[tenantKey] = {
+            isAuthenticated: false,
+            firmUser: null,
+            permissions: [],
+            firm: null,
+        };
+    }
+
+    return tenants[tenantKey];
+}
+
+function defineTenantProxy(session, tenantKey, propertyName, defaultValue) {
+    Object.defineProperty(session, propertyName, {
+        configurable: true,
+        enumerable: true,
+        get() {
+            const tenantSession = session.tenants?.[tenantKey];
+            if (!tenantSession) {
+                return defaultValue;
+            }
+
+            const value = tenantSession[propertyName];
+            if (value === undefined || value === null) {
+                return defaultValue;
+            }
+
+            if (propertyName === "permissions" && !Array.isArray(value)) {
+                return DEFAULT_ARRAY;
+            }
+
+            return value;
+        },
+        set(value) {
+            const tenants = ensureTenantsContainer(session);
+            const tenantSession = tenants[tenantKey] || (tenants[tenantKey] = {});
+
+            if (value === undefined) {
+                delete tenantSession[propertyName];
+                return;
+            }
+
+            tenantSession[propertyName] = value;
+        },
+    });
+}
+
+module.exports = (req, res, next) => {
+    const tenantKey = req.tenantKey;
+    if (!tenantKey || !req.session) {
+        res.locals.firmUser = null;
+        res.locals.permissions = DEFAULT_ARRAY;
+        return next();
+    }
+
+    const tenantSession = ensureTenantEntry(req.session, tenantKey);
+
+    defineTenantProxy(req.session, tenantKey, "firmUser", null);
+    defineTenantProxy(req.session, tenantKey, "permissions", DEFAULT_ARRAY);
+    defineTenantProxy(req.session, tenantKey, "firm", null);
+    defineTenantProxy(req.session, tenantKey, "isAuthenticated", false);
+
+    req.tenantSession = tenantSession;
+    res.locals.firmUser = tenantSession.firmUser || null;
+    res.locals.permissions = Array.isArray(tenantSession.permissions)
+        ? tenantSession.permissions
+        : DEFAULT_ARRAY;
+
+    next();
+};


### PR DESCRIPTION
## Summary
- add a middleware that partitions session state per tenant and exposes tenant-specific helpers
- update authentication, logout, and app bootstrap to work with tenant-scoped session data

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68e5d313557c8322bc57824f5a9ba507